### PR TITLE
clean up tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,6 +8,20 @@ on:
       - main
 
 jobs:
+  lib-check:
+    name: Static analysis of /lib for Python 3.5
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Set up Python 3.5
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.5
+    - name: Install dependencies
+      run: python3 -m pip install tox
+    - name: Run static analysis for /lib for 3.5
+      run: tox -vve static-lib
   static-analysis:
     name: Static analysis
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,8 +16,12 @@ jobs:
       uses: actions/checkout@v2
     - name: Install dependencies
       run: python3 -m pip install tox
-    - name: Run static analysis
-      run: tox -vve static
+    - name: Run static analysis (charm)
+      run: tox -vve static-charm
+    - name: Run static analysis (unit tests)
+      run: tox -vve static-unit
+    - name: Run static analysis (integration tests)
+      run: tox -vve static-integration
   lint:
     name: Lint
     runs-on: ubuntu-latest

--- a/lib/charms/alertmanager_k8s/v0/alertmanager_dispatch.py
+++ b/lib/charms/alertmanager_k8s/v0/alertmanager_dispatch.py
@@ -40,7 +40,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 2
+LIBPATCH = 3
 
 # Set to match metadata.yaml
 INTERFACE_NAME = "alertmanager_dispatch"
@@ -171,10 +171,12 @@ class AlertmanagerConsumer(RelationManagerBase):
     def get_cluster_info(self) -> List[str]:
         """Returns a list of ip addresses of all the alertmanager units."""
         alertmanagers = []  # type: List[str]
-        if not (relation := self.charm.model.get_relation(self.name)):
+        relation = self.charm.model.get_relation(self.name)
+        if not relation:
             return alertmanagers
         for unit in relation.units:
-            if address := relation.data[unit].get("public_address"):
+            address = relation.data[unit].get("public_address")
+            if address:
                 alertmanagers.append(address)
         return sorted(alertmanagers)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ copyright-regexp = "Copyright\\s\\d{4}([-,]\\d{4})*\\s+%(author)s"
 [tool.mypy]
 pretty = true
 python_version = 3.8
-mypy_path = "$MYPY_CONFIG_FILE_DIR/src:$MYPY_CONFIG_FILE_DIR/lib:$MYPY_CONFIG_FILE_DIR/tests/unit"
+mypy_path = "$MYPY_CONFIG_FILE_DIR/src:$MYPY_CONFIG_FILE_DIR/lib"
 follow_imports = "normal"
 warn_redundant_casts = true
 warn_unused_ignores = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ allow_redefinition = true
 
 # Ignore libraries that do not have type hint nor stubs
 [[tool.mypy.overrides]]
-module = ["ops.*", "lightkube.*", "git.*", "pytest_operator.*"]
+module = ["ops.*", "lightkube.*", "git.*", "pytest_operator.*", "validators.*"]
 ignore_missing_imports = true
 
 [tool.pytest.ini_options]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
 # Copyright 2021 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-git+https://github.com/canonical/operator/#egg=ops
+#git+https://github.com/canonical/operator/#egg=ops
+git+https://github.com/sed-i/operator@bugfix/make_dirs#egg=ops
 PyYAML
 lightkube
 lightkube-models

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,7 @@
 # Copyright 2021 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-#git+https://github.com/canonical/operator/#egg=ops
-git+https://github.com/sed-i/operator@bugfix/make_dirs#egg=ops
+git+https://github.com/canonical/operator/#egg=ops
 PyYAML
 lightkube
 lightkube-models

--- a/src/charm.py
+++ b/src/charm.py
@@ -302,7 +302,7 @@ class AlertmanagerCharm(CharmBase):
         )
 
         if config_hash != self._stored.config_hash:
-            self.container.push(self._config_path, config_yaml)
+            self.container.push(self._config_path, config_yaml, make_dirs=True)
 
             # Send an HTTP POST to alertmanager to hot-reload the config.
             # This reduces down-time compared to restarting the service.

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -114,6 +114,6 @@ async def is_alertmanage_unit_up(ops_test, app_name, unit_num):
 
 async def is_alertmanager_up(ops_test, app_name):
     return all(
-        is_alertmanage_unit_up(ops_test, app_name, unit_num)
+        await is_alertmanage_unit_up(ops_test, app_name, unit_num)
         for unit_num in range(len(ops_test.model.applications[app_name].units))
     )

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -91,7 +91,7 @@ async def get_leader_unit_num(ops_test: OpsTest, app_name: str):
     return is_leader.index(True)
 
 
-async def is_leader_elected(ops_test, app_name):
+async def is_leader_elected(ops_test: OpsTest, app_name: str):
     units = ops_test.model.applications[app_name].units
     return any([await units[i].is_leader_from_status() for i in range(len(units))])
 
@@ -103,7 +103,7 @@ async def block_until_leader_elected(ops_test: OpsTest, app_name: str):
         await asyncio.sleep(5)
 
 
-async def is_alertmanage_unit_up(ops_test, app_name, unit_num):
+async def is_alertmanage_unit_up(ops_test: OpsTest, app_name: str, unit_num: int):
     address = await get_unit_address(ops_test, app_name, unit_num)
     url = f"http://{address}:9093"
     logger.info("am public address: %s", url)
@@ -112,7 +112,7 @@ async def is_alertmanage_unit_up(ops_test, app_name, unit_num):
     return response.code == 200 and "versionInfo" in json.loads(response.read())
 
 
-async def is_alertmanager_up(ops_test, app_name):
+async def is_alertmanager_up(ops_test: OpsTest, app_name: str):
     return all(
         await is_alertmanage_unit_up(ops_test, app_name, unit_num)
         for unit_num in range(len(ops_test.model.applications[app_name].units))

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -114,6 +114,8 @@ async def is_alertmanage_unit_up(ops_test: OpsTest, app_name: str, unit_num: int
 
 async def is_alertmanager_up(ops_test: OpsTest, app_name: str):
     return all(
-        await is_alertmanage_unit_up(ops_test, app_name, unit_num)
-        for unit_num in range(len(ops_test.model.applications[app_name].units))
+        [
+            await is_alertmanage_unit_up(ops_test, app_name, unit_num)
+            for unit_num in range(len(ops_test.model.applications[app_name].units))
+        ]
     )

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -4,12 +4,14 @@
 """Helper functions for writing tests."""
 
 import asyncio
+import json
 import logging
+import urllib.request
 from typing import Dict
 
 from pytest_operator.plugin import OpsTest
 
-log = logging.getLogger(__name__)
+logger = logging.getLogger(__name__)
 
 
 async def get_unit_address(ops_test: OpsTest, app_name: str, unit_num: int) -> str:
@@ -52,9 +54,9 @@ async def cli_upgrade_from_path_and_wait(
         *resource_args,
     ]
 
-    retcode, stdout, stderr = await ops_test._run(*cmd)
+    retcode, stdout, stderr = await ops_test.run(*cmd)
     assert retcode == 0, f"Upgrade failed: {(stderr or stdout).strip()}"
-    log.info(stdout)
+    logger.info(stdout)
     await ops_test.model.wait_for_idle(apps=[alias], status=wait_for_status, timeout=120)
 
 
@@ -85,7 +87,7 @@ class IPAddressWorkaround:
 async def get_leader_unit_num(ops_test: OpsTest, app_name: str):
     units = ops_test.model.applications[app_name].units
     is_leader = [await units[i].is_leader_from_status() for i in range(len(units))]
-    log.info("Leaders: %s", is_leader)
+    logger.info("Leaders: %s", is_leader)
     return is_leader.index(True)
 
 
@@ -99,3 +101,19 @@ async def block_until_leader_elected(ops_test: OpsTest, app_name: str):
     # block_until does not take async (yet?) https://github.com/juju/python-libjuju/issues/609
     while not await is_leader_elected(ops_test, app_name):
         await asyncio.sleep(5)
+
+
+async def is_alertmanage_unit_up(ops_test, app_name, unit_num):
+    address = await get_unit_address(ops_test, app_name, unit_num)
+    url = f"http://{address}:9093"
+    logger.info("am public address: %s", url)
+
+    response = urllib.request.urlopen(f"{url}/api/v2/status", data=None, timeout=2.0)
+    return response.code == 200 and "versionInfo" in json.loads(response.read())
+
+
+async def is_alertmanager_up(ops_test, app_name):
+    return all(
+        is_alertmanage_unit_up(ops_test, app_name, unit_num)
+        for unit_num in range(len(ops_test.model.applications[app_name].units))
+    )

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 import pytest
 import yaml
-from helpers import IPAddressWorkaround, is_alertmanager_up  # type: ignore[import]
+from helpers import IPAddressWorkaround, is_alertmanager_up
 
 logger = logging.getLogger(__name__)
 

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import pytest
 import yaml
 from helpers import IPAddressWorkaround, is_alertmanager_up
+from pytest_operator.plugin import OpsTest
 
 logger = logging.getLogger(__name__)
 
@@ -18,7 +19,7 @@ resources = {"alertmanager-image": METADATA["resources"]["alertmanager-image"]["
 
 
 @pytest.mark.abort_on_fail
-async def test_build_and_deploy(ops_test, charm_under_test):
+async def test_build_and_deploy(ops_test: OpsTest, charm_under_test):
     """Build the charm-under-test and deploy it together with related charms.
 
     Assert on the unit status before any relations/configurations take place.

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -25,7 +25,7 @@ async def test_build_and_deploy(ops_test: OpsTest, charm_under_test):
     Assert on the unit status before any relations/configurations take place.
     """
     # deploy charm from local source folder
-    await ops_test.model.deploy(charm_under_test, resources=resources, application_name="am")
+    await ops_test.model.deploy(charm_under_test, resources=resources, application_name=app_name)
 
     async with IPAddressWorkaround(ops_test):
         await ops_test.model.wait_for_idle(apps=[app_name], status="active", timeout=1000)

--- a/tests/integration/test_kubectl_delete.py
+++ b/tests/integration/test_kubectl_delete.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 import pytest
 import yaml
-from helpers import IPAddressWorkaround, is_alertmanager_up  # type: ignore[import]
+from helpers import IPAddressWorkaround, is_alertmanager_up
 
 logger = logging.getLogger(__name__)
 

--- a/tests/integration/test_kubectl_delete.py
+++ b/tests/integration/test_kubectl_delete.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import pytest
 import yaml
 from helpers import IPAddressWorkaround, is_alertmanager_up
+from pytest_operator.plugin import OpsTest
 
 logger = logging.getLogger(__name__)
 
@@ -18,7 +19,7 @@ resources = {"alertmanager-image": METADATA["resources"]["alertmanager-image"]["
 
 
 @pytest.mark.abort_on_fail
-async def test_deploy_from_local_path(ops_test, charm_under_test):
+async def test_deploy_from_local_path(ops_test: OpsTest, charm_under_test):
     """Deploy the charm-under-test."""
     logger.debug("deploy local charm")
 
@@ -31,7 +32,7 @@ async def test_deploy_from_local_path(ops_test, charm_under_test):
 
 
 @pytest.mark.abort_on_fail
-async def test_kubectl_delete_pod(ops_test):
+async def test_kubectl_delete_pod(ops_test: OpsTest):
     pod_name = f"{app_name}-0"
 
     cmd = [

--- a/tests/integration/test_kubectl_delete.py
+++ b/tests/integration/test_kubectl_delete.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+# Copyright 2022 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+
+import logging
+from pathlib import Path
+
+import pytest
+import yaml
+from helpers import IPAddressWorkaround, is_alertmanager_up  # type: ignore[import]
+
+logger = logging.getLogger(__name__)
+
+METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
+app_name = METADATA["name"]
+resources = {"alertmanager-image": METADATA["resources"]["alertmanager-image"]["upstream-source"]}
+
+
+@pytest.mark.abort_on_fail
+async def test_deploy_from_local_path(ops_test, charm_under_test):
+    """Deploy the charm-under-test."""
+    logger.debug("deploy local charm")
+
+    async with IPAddressWorkaround(ops_test):
+        await ops_test.model.deploy(
+            charm_under_test, application_name=app_name, resources=resources
+        )
+        await ops_test.model.wait_for_idle(apps=[app_name], status="active", timeout=1000)
+        await is_alertmanager_up(ops_test, app_name)
+
+
+@pytest.mark.abort_on_fail
+async def test_kubectl_delete_pod(ops_test):
+    pod_name = f"{app_name}-0"
+
+    cmd = [
+        "sg",
+        "microk8s",
+        "-c",
+        " ".join(["microk8s.kubectl", "delete", "pod", "-n", ops_test.model_name, pod_name]),
+    ]
+
+    logger.debug(
+        "Removing pod '%s' from model '%s' with cmd: %s", pod_name, ops_test.model_name, cmd
+    )
+
+    retcode, stdout, stderr = await ops_test.run(*cmd)
+    assert retcode == 0, f"kubectl failed: {(stderr or stdout).strip()}"
+    logger.debug(stdout)
+    await ops_test.model.block_until(lambda: len(ops_test.model.applications[app_name].units) > 0)
+    await ops_test.model.wait_for_idle(apps=[app_name], status="active", timeout=1000)
+    assert await is_alertmanager_up(ops_test, app_name)

--- a/tests/integration/test_rescale_charm.py
+++ b/tests/integration/test_rescale_charm.py
@@ -22,6 +22,7 @@ from helpers import (
     get_leader_unit_num,
     is_alertmanager_up,
 )
+from pytest_operator.plugin import OpsTest
 
 logger = logging.getLogger(__name__)
 
@@ -31,7 +32,7 @@ resources = {"alertmanager-image": METADATA["resources"]["alertmanager-image"]["
 
 
 @pytest.mark.abort_on_fail
-async def test_deploy_multiple_units(ops_test, charm_under_test):
+async def test_deploy_multiple_units(ops_test: OpsTest, charm_under_test):
     """Deploy the charm-under-test."""
     logger.info("build charm from local source folder")
 
@@ -57,7 +58,7 @@ async def test_deploy_multiple_units(ops_test, charm_under_test):
 
 
 @pytest.mark.abort_on_fail
-async def test_scale_down_to_single_unit_with_leadership_change(ops_test):
+async def test_scale_down_to_single_unit_with_leadership_change(ops_test: OpsTest):
     """Scale down below current leader to trigger a leadership change event."""
     await ops_test.model.applications[app_name].scale(scale=1)
     await ops_test.model.wait_for_idle(
@@ -67,7 +68,7 @@ async def test_scale_down_to_single_unit_with_leadership_change(ops_test):
 
 
 @pytest.mark.abort_on_fail
-async def test_scale_up_from_single_unit(ops_test):
+async def test_scale_up_from_single_unit(ops_test: OpsTest):
     """Add a few more units."""
     await ops_test.model.applications[app_name].scale(scale_change=2)
     await ops_test.model.wait_for_idle(

--- a/tests/integration/test_rescale_charm.py
+++ b/tests/integration/test_rescale_charm.py
@@ -62,33 +62,27 @@ async def test_deploy_multiple_units(ops_test, charm_under_test):
 async def test_scale_down_to_single_unit_with_leadership_change(ops_test):
     """Scale down below current leader to trigger a leadership change event."""
     await ops_test.model.applications[app_name].scale(scale=1)
-
-    # block_until is needed because of https://github.com/juju/python-libjuju/issues/608
-    await ops_test.model.block_until(lambda: len(ops_test.model.applications[app_name].units) == 1)
-
-    await ops_test.model.wait_for_idle(apps=[app_name], status="active", timeout=1000)
+    await ops_test.model.wait_for_idle(
+        apps=[app_name], status="active", timeout=1000, wait_for_exact_units=1
+    )
 
 
 @pytest.mark.abort_on_fail
 async def test_scale_up_from_single_unit(ops_test):
     """Add a few more units."""
     await ops_test.model.applications[app_name].scale(scale_change=2)
-
-    # block_until is needed because of https://github.com/juju/python-libjuju/issues/608
-    await ops_test.model.block_until(lambda: len(ops_test.model.applications[app_name].units) == 3)
-
-    await ops_test.model.wait_for_idle(apps=[app_name], status="active", timeout=1000)
+    await ops_test.model.wait_for_idle(
+        apps=[app_name], status="active", timeout=1000, wait_for_exact_units=3
+    )
 
 
 @pytest.mark.abort_on_fail
 async def test_scale_down_to_single_unit_without_leadership_change(ops_test):
     """Remove a few units."""
     await ops_test.model.applications[app_name].scale(scale_change=-2)
-
-    # block_until is needed because of https://github.com/juju/python-libjuju/issues/608
-    await ops_test.model.block_until(lambda: len(ops_test.model.applications[app_name].units) == 1)
-
-    await ops_test.model.wait_for_idle(apps=[app_name], status="active", timeout=1000)
+    await ops_test.model.wait_for_idle(
+        apps=[app_name], status="active", timeout=1000, wait_for_exact_units=1
+    )
 
 
 @pytest.mark.abort_on_fail

--- a/tests/integration/test_rescale_charm.py
+++ b/tests/integration/test_rescale_charm.py
@@ -16,7 +16,7 @@ from pathlib import Path
 
 import pytest
 import yaml
-from helpers import (  # type: ignore[import]
+from helpers import (
     IPAddressWorkaround,
     block_until_leader_elected,
     get_leader_unit_num,

--- a/tests/integration/test_upgrade_charm.py
+++ b/tests/integration/test_upgrade_charm.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 import pytest
 import yaml
-from helpers import IPAddressWorkaround, is_alertmanager_up  # type: ignore[import]
+from helpers import IPAddressWorkaround, is_alertmanager_up
 
 logger = logging.getLogger(__name__)
 

--- a/tests/integration/test_upgrade_charm.py
+++ b/tests/integration/test_upgrade_charm.py
@@ -3,14 +3,12 @@
 # See LICENSE file for licensing details.
 
 
-import json
 import logging
-import urllib.request
 from pathlib import Path
 
 import pytest
 import yaml
-from helpers import IPAddressWorkaround, get_unit_address  # type: ignore[attr-defined]
+from helpers import IPAddressWorkaround, is_alertmanager_up  # type: ignore[import]
 
 logger = logging.getLogger(__name__)
 
@@ -39,14 +37,4 @@ async def test_build_and_deploy(ops_test, charm_under_test):
             path=charm_under_test, resources=resources
         )
         await ops_test.model.wait_for_idle(apps=[app_name], status="active", timeout=1000)
-
-
-@pytest.mark.abort_on_fail
-async def test_alertmanager_is_up(ops_test):
-    address = await get_unit_address(ops_test, app_name, 0)
-    url = f"http://{address}:9093"
-    logger.info("am public address: %s", url)
-
-    response = urllib.request.urlopen(f"{url}/api/v2/status", data=None, timeout=2.0)
-    assert response.code == 200
-    assert "versionInfo" in json.loads(response.read())
+        assert await is_alertmanager_up(ops_test, app_name)

--- a/tests/integration/test_upgrade_charm.py
+++ b/tests/integration/test_upgrade_charm.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import pytest
 import yaml
 from helpers import IPAddressWorkaround, is_alertmanager_up
+from pytest_operator.plugin import OpsTest
 
 logger = logging.getLogger(__name__)
 
@@ -18,7 +19,7 @@ resources = {"alertmanager-image": METADATA["resources"]["alertmanager-image"]["
 
 
 @pytest.mark.abort_on_fail
-async def test_build_and_deploy(ops_test, charm_under_test):
+async def test_build_and_deploy(ops_test: OpsTest, charm_under_test):
     """Build the charm-under-test and deploy it together with related charms.
 
     Assert on the unit status before any relations/configurations take place.

--- a/tests/unit/charm/test_push_config_to_workload_on_startup.py
+++ b/tests/unit/charm/test_push_config_to_workload_on_startup.py
@@ -2,16 +2,19 @@
 # Copyright 2021 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-import hypothesis.strategies as st
-from hypothesis import given
+import logging
 import unittest
 from unittest.mock import patch
+
+import hypothesis.strategies as st
 import validators
-from ops.testing import Harness
-from charm import Alertmanager, AlertmanagerCharm
-from helpers import patch_network_get, tautology  # type: ignore[import]
 import yaml
-import logging
+from helpers import patch_network_get, tautology
+from hypothesis import given
+from ops.testing import Harness
+
+from charm import Alertmanager, AlertmanagerCharm
+
 logger = logging.getLogger(__name__)
 
 
@@ -43,19 +46,27 @@ class TestPushConfigToWorkloadOnStartup(unittest.TestCase):
         self.harness.set_leader(is_leader)
 
         # THEN amtool config is rendered
-        amtool_config = yaml.safe_load(self.harness.charm.container.pull(self.harness.charm._amtool_config_path))
+        amtool_config = yaml.safe_load(
+            self.harness.charm.container.pull(self.harness.charm._amtool_config_path)
+        )
         self.assertTrue(validators.url(amtool_config["alertmanager.url"]))
 
         # AND alertmanager config is rendered
-        am_config = yaml.safe_load(self.harness.charm.container.pull(self.harness.charm._config_path))
+        am_config = yaml.safe_load(
+            self.harness.charm.container.pull(self.harness.charm._config_path)
+        )
         self.assertGreaterEqual(am_config.keys(), {"global", "route", "receivers"})
 
         # AND path to config file is part of pebble layer command
-        command = self.harness.get_container_pebble_plan(self.harness.charm._container_name).services[self.harness.charm._service_name].command
+        command = (
+            self.harness.get_container_pebble_plan(self.harness.charm._container_name)
+            .services[self.harness.charm._service_name]
+            .command
+        )
         self.assertIn(f"--config.file={self.harness.charm._config_path}", command)
 
         # AND peer clusters cli arg is not present in pebble layer command
-        self.assertNotIn(f"--cluster.peer=", command)
+        self.assertNotIn("--cluster.peer=", command)
 
     @given(st.booleans(), st.integers(2, 10))
     def test_multi_unit_cluster(self, is_leader, num_units):
@@ -68,14 +79,22 @@ class TestPushConfigToWorkloadOnStartup(unittest.TestCase):
             # WHEN multiple units are present
             for i in range(1, num_units):
                 self.harness.add_relation_unit(self.peer_rel_id, f"{self.app_name}/{i}")
-                self.harness.update_relation_data(self.peer_rel_id, f"{self.app_name}/{i}", {"private_address": f"{2*i}.{2*i}.{2*i}.{2*i}"})
+                self.harness.update_relation_data(
+                    self.peer_rel_id,
+                    f"{self.app_name}/{i}",
+                    {"private_address": f"{2*i}.{2*i}.{2*i}.{2*i}"},
+                )
 
             self.assertEqual(self.harness.model.app.planned_units(), num_units)
             self.harness.set_leader(is_leader)
 
             # THEN peer clusters cli arg is present in pebble layer command
-            command = self.harness.get_container_pebble_plan(self.harness.charm._container_name).services[self.harness.charm._service_name].command
-            self.assertIn(f"--cluster.peer=", command)
+            command = (
+                self.harness.get_container_pebble_plan(self.harness.charm._container_name)
+                .services[self.harness.charm._service_name]
+                .command
+            )
+            self.assertIn("--cluster.peer=", command)
 
         finally:
             # cleanup added units to prep for reentry by hypothesis' strategy

--- a/tests/unit/charm/test_push_config_to_workload_on_startup.py
+++ b/tests/unit/charm/test_push_config_to_workload_on_startup.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+# Copyright 2021 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import hypothesis.strategies as st
+from hypothesis import given
+import unittest
+from unittest.mock import patch
+import validators
+from ops.testing import Harness
+from charm import Alertmanager, AlertmanagerCharm
+from helpers import patch_network_get, tautology  # type: ignore[import]
+import yaml
+import logging
+logger = logging.getLogger(__name__)
+
+
+class TestPushConfigToWorkloadOnStartup(unittest.TestCase):
+    """Feature: Push config to workload on startup.
+
+    Background: Charm starts up with initial hooks.
+    """
+
+    @patch_network_get(private_address="1.1.1.1")
+    @patch.object(Alertmanager, "reload", tautology)
+    @patch("charm.KubernetesServicePatch", lambda *a, **kw: None)
+    def setUp(self, *_):
+        self.harness = Harness(AlertmanagerCharm)
+        self.addCleanup(self.harness.cleanup)
+
+        # self.harness.charm.app.name does not exist before .begin()
+        # https://github.com/canonical/operator/issues/675
+        # self.peer_rel_id = self.harness.add_relation("replicas", self.app_name)
+        self.app_name = "alertmanager-k8s"
+        self.peer_rel_id = self.harness.add_relation("replicas", self.app_name)
+        self.harness.begin_with_initial_hooks()
+
+    @given(st.booleans())
+    def test_single_unit_cluster(self, is_leader):
+        """Scenario: Current unit is the only unit present."""
+        # WHEN only one unit is
+        self.assertEqual(self.harness.model.app.planned_units(), 1)
+        self.harness.set_leader(is_leader)
+
+        # THEN amtool config is rendered
+        amtool_config = yaml.safe_load(self.harness.charm.container.pull(self.harness.charm._amtool_config_path))
+        self.assertTrue(validators.url(amtool_config["alertmanager.url"]))
+
+        # AND alertmanager config is rendered
+        am_config = yaml.safe_load(self.harness.charm.container.pull(self.harness.charm._config_path))
+        self.assertGreaterEqual(am_config.keys(), {"global", "route", "receivers"})
+
+        # AND path to config file is part of pebble layer command
+        command = self.harness.get_container_pebble_plan(self.harness.charm._container_name).services[self.harness.charm._service_name].command
+        self.assertIn(f"--config.file={self.harness.charm._config_path}", command)
+
+        # AND peer clusters cli arg is not present in pebble layer command
+        self.assertNotIn(f"--cluster.peer=", command)
+
+    @given(st.booleans(), st.integers(2, 10))
+    def test_multi_unit_cluster(self, is_leader, num_units):
+        """Scenario: Current unit is a part of a multi-unit cluster."""
+        # without the try-finally, if any assertion fails, then hypothesis would reenter without
+        # the cleanup, carrying forward the units that were previously added
+        try:
+            self.assertEqual(self.harness.model.app.planned_units(), 1)
+
+            # WHEN multiple units are present
+            for i in range(1, num_units):
+                self.harness.add_relation_unit(self.peer_rel_id, f"{self.app_name}/{i}")
+                self.harness.update_relation_data(self.peer_rel_id, f"{self.app_name}/{i}", {"private_address": f"{2*i}.{2*i}.{2*i}.{2*i}"})
+
+            self.assertEqual(self.harness.model.app.planned_units(), num_units)
+            self.harness.set_leader(is_leader)
+
+            # THEN peer clusters cli arg is present in pebble layer command
+            command = self.harness.get_container_pebble_plan(self.harness.charm._container_name).services[self.harness.charm._service_name].command
+            self.assertIn(f"--cluster.peer=", command)
+
+        finally:
+            # cleanup added units to prep for reentry by hypothesis' strategy
+            for i in reversed(range(1, num_units)):
+                self.harness.remove_relation_unit(self.peer_rel_id, f"{self.app_name}/{i}")

--- a/tests/unit/helpers.py
+++ b/tests/unit/helpers.py
@@ -4,7 +4,7 @@
 
 """Helper functions for writing tests."""
 
-from typing import Callable, Dict
+from typing import Callable
 from unittest.mock import patch
 
 
@@ -36,22 +36,3 @@ def no_op(*args, **kwargs) -> None:
 
 def tautology(*args, **kwargs) -> bool:
     return True
-
-
-class PushPullMock:
-    """Helper class for mocking filesystem operations."""
-
-    def __init__(self):
-        self._filesystem: Dict[str, str] = {}
-
-    def pull(self, path: str, *args, **kwargs) -> str:
-        return self._filesystem.get(path, "")
-
-    def push(self, path: str, source: str, *args, **kwargs) -> None:
-        self._filesystem[path] = source
-
-    def patch_push(self) -> Callable:
-        return patch("ops.testing._TestingPebbleClient.push", self.push)
-
-    def patch_pull(self) -> Callable:
-        return patch("ops.testing._TestingPebbleClient.pull", self.pull)

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -7,7 +7,7 @@ from unittest.mock import patch
 
 import ops
 import yaml
-from helpers import patch_network_get, tautology  # type: ignore[import]
+from helpers import patch_network_get, tautology
 from ops.model import ActiveStatus, BlockedStatus
 from ops.testing import Harness
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -7,7 +7,7 @@ from unittest.mock import patch
 
 import ops
 import yaml
-from helpers import patch_network_get, tautology
+from helpers import patch_network_get, tautology  # type: ignore[import]
 from ops.model import ActiveStatus, BlockedStatus
 from ops.testing import Harness
 

--- a/tox.ini
+++ b/tox.ini
@@ -7,9 +7,9 @@ skip_missing_interpreters = True
 envlist = lint, static, unit
 
 [vars]
-src_path = {toxinidir}/src/
-tst_path = {toxinidir}/tests/
-lib_path = {toxinidir}/lib/charms/alertmanager_k8s/
+src_path = {toxinidir}/src
+tst_path = {toxinidir}/tests
+lib_path = {toxinidir}/lib/charms/alertmanager_k8s
 all_path = {[vars]src_path} {[vars]tst_path} {[vars]lib_path}
 
 [testenv]
@@ -82,7 +82,11 @@ description = Run unit tests
 deps =
     pytest
     coverage[toml]
+    hypothesis
+    validators
     -r{toxinidir}/requirements.txt
+#setenv =
+#    PYTHONPATH = {toxinidir}:{toxinidir}/lib:{[vars]src_path}:{[vars]tst_path}/unit
 commands =
     coverage run \
       --source={[vars]src_path},{[vars]lib_path} \

--- a/tox.ini
+++ b/tox.ini
@@ -70,7 +70,8 @@ deps =
     # pip-check-reqs does not yet work with recent pip
     pip-check-reqs
     pip<=21.1.3
-    charm,lib,unit: {[testenv:unit]deps}
+    charm,lib: -r{toxinidir}/requirements.txt
+    unit: {[testenv:unit]deps}
     integration: {[testenv:integration]deps}
 commands =
     charm: pip-missing-reqs {toxinidir}/src {toxinidir}/lib --requirements-file={toxinidir}/requirements.txt

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 [tox]
 skipsdist=True
 skip_missing_interpreters = True
-envlist = lint, static, unit
+envlist = lint, static-{charm,unit,integration}, unit
 
 [vars]
 src_path = {toxinidir}/src
@@ -57,25 +57,28 @@ commands =
     isort --check-only --diff {[vars]all_path}
     black --check --diff {[vars]all_path}
 
-[testenv:static]
+[testenv:static-{charm,unit,integration}]
 description = Run static analysis checks
+setenv =
+    unit: MYPYPATH = {[vars]tst_path}/unit
+    integration: MYPYPATH = {[vars]tst_path}/integration
 deps =
-    -r{toxinidir}/requirements.txt
     mypy
     types-PyYAML
-    pytest
-    pytest-operator
-    juju
     types-setuptools
     types-toml
     # pip-check-reqs does not yet work with recent pip
     pip-check-reqs
     pip<=21.1.3
+    charm,unit: {[testenv:unit]deps}
+    integration: {[testenv:integration]deps}
 commands =
-    pip-missing-reqs {toxinidir}/src {toxinidir}/lib --requirements-file={toxinidir}/requirements.txt
-    pip-extra-reqs {toxinidir}/src {toxinidir}/lib --requirements-file={toxinidir}/requirements.txt
-    mypy {[vars]all_path} {posargs}
-    mypy --python-version 3.5 {[vars]lib_path} {posargs}
+    charm: pip-missing-reqs {toxinidir}/src {toxinidir}/lib --requirements-file={toxinidir}/requirements.txt
+    charm: pip-extra-reqs {toxinidir}/src {toxinidir}/lib --requirements-file={toxinidir}/requirements.txt
+    charm: mypy {[vars]src_path} {posargs}
+    charm: mypy --python-version 3.5 {[vars]lib_path} {posargs}
+    unit: mypy {[vars]tst_path}/unit {posargs}
+    integration: mypy {[vars]tst_path}/integration {posargs}
 
 [testenv:unit]
 description = Run unit tests

--- a/tox.ini
+++ b/tox.ini
@@ -70,7 +70,8 @@ deps =
     # pip-check-reqs does not yet work with recent pip
     pip-check-reqs
     charm: pip<=21.1.3
-    charm,lib: -r{toxinidir}/requirements.txt
+    charm: -r{toxinidir}/requirements.txt
+    lib: git+https://github.com/canonical/operator#egg=ops
     unit: {[testenv:unit]deps}
     integration: {[testenv:integration]deps}
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -17,6 +17,7 @@ basepython = python3
 setenv =
   PYTHONPATH = {toxinidir}:{toxinidir}/lib:{[vars]src_path}
   PYTHONBREAKPOINT=ipdb.set_trace
+  PY_COLORS=1
 passenv =
   PYTHONPATH
   HOME

--- a/tox.ini
+++ b/tox.ini
@@ -69,7 +69,7 @@ deps =
     types-toml
     # pip-check-reqs does not yet work with recent pip
     pip-check-reqs
-    pip<=21.1.3
+    charm: pip<=21.1.3
     charm,lib: -r{toxinidir}/requirements.txt
     unit: {[testenv:unit]deps}
     integration: {[testenv:integration]deps}

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 [tox]
 skipsdist=True
 skip_missing_interpreters = True
-envlist = lint, static-{charm,unit,integration}, unit
+envlist = lint, static-{charm,lib,unit,integration}, unit
 
 [vars]
 src_path = {toxinidir}/src
@@ -57,7 +57,7 @@ commands =
     isort --check-only --diff {[vars]all_path}
     black --check --diff {[vars]all_path}
 
-[testenv:static-{charm,unit,integration}]
+[testenv:static-{charm,lib,unit,integration}]
 description = Run static analysis checks
 setenv =
     unit: MYPYPATH = {[vars]tst_path}/unit
@@ -70,13 +70,13 @@ deps =
     # pip-check-reqs does not yet work with recent pip
     pip-check-reqs
     pip<=21.1.3
-    charm,unit: {[testenv:unit]deps}
+    charm,lib,unit: {[testenv:unit]deps}
     integration: {[testenv:integration]deps}
 commands =
     charm: pip-missing-reqs {toxinidir}/src {toxinidir}/lib --requirements-file={toxinidir}/requirements.txt
     charm: pip-extra-reqs {toxinidir}/src {toxinidir}/lib --requirements-file={toxinidir}/requirements.txt
     charm: mypy {[vars]src_path} {posargs}
-    charm: mypy --python-version 3.5 {[vars]lib_path} {posargs}
+    lib: mypy --python-version 3.5 {[vars]lib_path} {posargs}
     unit: mypy {[vars]tst_path}/unit {posargs}
     integration: mypy {[vars]tst_path}/integration {posargs}
 

--- a/tox.ini
+++ b/tox.ini
@@ -88,8 +88,6 @@ deps =
     hypothesis
     validators
     -r{toxinidir}/requirements.txt
-#setenv =
-#    PYTHONPATH = {toxinidir}:{toxinidir}/lib:{[vars]src_path}:{[vars]tst_path}/unit
 commands =
     coverage run \
       --source={[vars]src_path},{[vars]lib_path} \
@@ -112,8 +110,8 @@ lma_bundle_dir = {envtmpdir}/lma-light-bundle
 deps =
     # deps from lma-bundle - these are needed here because will be running pytest on lma-bundle
     jinja2
-    # git+https://github.com/juju/python-libjuju.git
-    juju
+    git+https://github.com/juju/python-libjuju.git
+    #juju
     pytest
     git+https://github.com/charmed-kubernetes/pytest-operator.git
 allowlist_externals =


### PR DESCRIPTION
This PR cleans up, upkeeps, improves and augments various testing aspects.

Checklist:
- [x] drop own push/pull mock
- [x] ops_test._run -> ops_test.run
- [x] start using [hypothesis](https://hypothesis.readthedocs.io/en/latest/quickstart.html)
- [x] add `PY_COLORS=1`
- [x] test again the upgrade charm test
- [x] lib-check workflow from grafana-operator
- [x] add `from pytest_operator.plugin import OpsTest` to integration tests.
- [x] itest: build charm in `tests/integration/conftest.py` (cf. grafana-operator)

Post merge:
- [ ] publish charm to edge
- [ ] publish charm lib

Descoped:
- [ ] improve coverage
- [ ] version freeze everything -- captured in #52 
- [ ] python-libjuju: deploy bundle with overlays: https://github.com/juju/python-libjuju/pull/566
- [ ] itests: gather()
- [ ] itest: if fetchlib produces a diff, then fail the test -- use https://github.com/canonical/charm-lib-checker-action
- [ ] use simme's action to auto collect logs on failure
- [ ] add `pytest-timestamps`
