### PR TITLE
Add upgrade and removal tests

### DIFF
--- a/tests/integration/test_rerelate_alertmanager_dispatch.py
+++ b/tests/integration/test_rerelate_alertmanager_dispatch.py
@@ -25,7 +25,7 @@ logger = logging.getLogger(__name__)
 METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
 app_name = METADATA["name"]
 resources = {"alertmanager-image": METADATA["resources"]["alertmanager-image"]["upstream-source"]}
-related_app = "related_app"
+related_app = "related-app"
 
 
 @pytest.mark.abort_on_fail

--- a/tests/integration/test_rerelate_alertmanager_dispatch.py
+++ b/tests/integration/test_rerelate_alertmanager_dispatch.py
@@ -61,6 +61,9 @@ async def test_rerelate(ops_test: OpsTest):
 @pytest.mark.abort_on_fail
 async def test_remove_related_app(ops_test: OpsTest):
     await ops_test.model.applications[related_app].remove()
+    # Block until it is really gone. Added after an itest failed when tried to redeploy:
+    # juju.errors.JujuError: ['cannot add application "related-app": application already exists']
+    await ops_test.model.block_until(lambda: related_app not in ops_test.model.applications)
     await ops_test.model.wait_for_idle(apps=[app_name], status="active", timeout=1000)
     assert await is_alertmanager_up(ops_test, app_name)
 

--- a/tests/integration/test_rerelate_alertmanager_dispatch.py
+++ b/tests/integration/test_rerelate_alertmanager_dispatch.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+# Copyright 2021 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""This test module tests alertmanager response to related apps being removed and re-related.
+
+1. Deploy the charm under test and a related app, relate them and wait for them to become idle.
+2. Remove the relation.
+3. Re-add the relation.
+4. Remove the related application.
+5. Redeploy the related application and add the relation back again.
+"""
+
+import asyncio
+import logging
+from pathlib import Path
+
+import pytest
+import yaml
+from helpers import is_alertmanager_up
+from pytest_operator.plugin import OpsTest
+
+logger = logging.getLogger(__name__)
+
+METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
+app_name = METADATA["name"]
+resources = {"alertmanager-image": METADATA["resources"]["alertmanager-image"]["upstream-source"]}
+related_app = "related_app"
+
+
+@pytest.mark.abort_on_fail
+async def test_build_and_deploy(ops_test: OpsTest, charm_under_test):
+    """Build the charm-under-test and deploy it together with related charms."""
+    await asyncio.gather(
+        ops_test.model.deploy(
+            charm_under_test, resources=resources, application_name=app_name, num_units=2
+        ),
+        ops_test.model.deploy("ch:prometheus-k8s", application_name=related_app, channel="edge"),
+    )
+
+    await ops_test.model.add_relation(app_name, related_app)
+    await ops_test.model.wait_for_idle(apps=[app_name, related_app], status="active", timeout=1000)
+
+    assert await is_alertmanager_up(ops_test, app_name)
+
+
+@pytest.mark.abort_on_fail
+async def test_remove_relation(ops_test: OpsTest):
+    await ops_test.model.applications[app_name].remove_relation(
+        "alertmanager_dispatch", related_app
+    )
+    await ops_test.model.wait_for_idle(apps=[app_name], status="active", timeout=1000)
+    assert await is_alertmanager_up(ops_test, app_name)
+
+
+@pytest.mark.abort_on_fail
+async def test_rerelate(ops_test: OpsTest):
+    await ops_test.model.add_relation(app_name, related_app)
+    await ops_test.model.wait_for_idle(apps=[app_name, related_app], status="active", timeout=1000)
+    assert await is_alertmanager_up(ops_test, app_name)
+
+
+@pytest.mark.abort_on_fail
+async def test_remove_related_app(ops_test: OpsTest):
+    await ops_test.model.applications[related_app].remove()
+    await ops_test.model.wait_for_idle(apps=[app_name], status="active", timeout=1000)
+    assert await is_alertmanager_up(ops_test, app_name)
+
+
+@pytest.mark.abort_on_fail
+async def test_rerelate_app(ops_test: OpsTest):
+    await ops_test.model.deploy("ch:prometheus-k8s", application_name=related_app, channel="edge")
+    await ops_test.model.add_relation(app_name, related_app)
+    await ops_test.model.wait_for_idle(apps=[app_name, related_app], status="active", timeout=1000)
+    assert await is_alertmanager_up(ops_test, app_name)

--- a/tests/integration/test_rerelate_alertmanager_dispatch.py
+++ b/tests/integration/test_rerelate_alertmanager_dispatch.py
@@ -46,9 +46,7 @@ async def test_build_and_deploy(ops_test: OpsTest, charm_under_test):
 
 @pytest.mark.abort_on_fail
 async def test_remove_relation(ops_test: OpsTest):
-    await ops_test.model.applications[app_name].remove_relation(
-        "alertmanager_dispatch", related_app
-    )
+    await ops_test.model.applications[app_name].remove_relation("alerting", related_app)
     await ops_test.model.wait_for_idle(apps=[app_name], status="active", timeout=1000)
     assert await is_alertmanager_up(ops_test, app_name)
 

--- a/tests/integration/test_upgrade_charm.py
+++ b/tests/integration/test_upgrade_charm.py
@@ -65,7 +65,7 @@ async def test_upgrade_local_with_local_with_relations(ops_test: OpsTest, charm_
 @pytest.mark.abort_on_fail
 async def test_upgrade_with_multiple_units(ops_test: OpsTest, charm_under_test):
     # Add unit
-    await ops_test.model.applications[app_name].add_units(count=1)
+    await ops_test.model.applications[app_name].scale(scale_change=1)
     await ops_test.model.wait_for_idle(
         apps=[app_name, "prom", "karma"], status="active", timeout=1000
     )

--- a/tests/integration/test_upgrade_charm.py
+++ b/tests/integration/test_upgrade_charm.py
@@ -2,13 +2,22 @@
 # Copyright 2021 Canonical Ltd.
 # See LICENSE file for licensing details.
 
+"""This test module tests alertmanager upgrade with and without relations present.
 
+1. Deploy the charm under test _from charmhub_.
+2. Refresh with locally built charm.
+3. Add all supported relations.
+4. Refresh with locally built charm.
+5. Add unit and refresh again (test multi unit upgrade with relations).
+"""
+
+import asyncio
 import logging
 from pathlib import Path
 
 import pytest
 import yaml
-from helpers import IPAddressWorkaround, is_alertmanager_up
+from helpers import is_alertmanager_up
 from pytest_operator.plugin import OpsTest
 
 logger = logging.getLogger(__name__)
@@ -19,23 +28,51 @@ resources = {"alertmanager-image": METADATA["resources"]["alertmanager-image"]["
 
 
 @pytest.mark.abort_on_fail
-async def test_build_and_deploy(ops_test: OpsTest, charm_under_test):
-    """Build the charm-under-test and deploy it together with related charms.
+async def test_upgrade_edge_with_local_in_isolation(ops_test: OpsTest, charm_under_test):
+    """Build the charm-under-test, deploy the charm from charmhub, and upgrade from path."""
+    logger.info("deploy charm from charmhub")
+    await ops_test.model.deploy("ch:alertmanager-k8s", application_name=app_name, channel="edge")
+    await ops_test.model.wait_for_idle(apps=[app_name], status="active", timeout=1000)
 
-    Assert on the unit status before any relations/configurations take place.
-    """
-    logger.info("build charm from local source folder")
+    logger.info("upgrade deployed charm with local charm %s", charm_under_test)
+    await ops_test.model.applications[app_name].refresh(path=charm_under_test, resources=resources)
+    await ops_test.model.wait_for_idle(apps=[app_name], status="active", timeout=1000)
+    assert await is_alertmanager_up(ops_test, app_name)
 
-    async with IPAddressWorkaround(ops_test):
-        logger.info("deploy charm from charmhub")
-        await ops_test.model.deploy(
-            "ch:alertmanager-k8s", application_name=app_name, channel="edge"
-        )
-        await ops_test.model.wait_for_idle(apps=[app_name], status="active", timeout=1000)
 
-        logger.info("upgrade deployed charm with local charm %s", charm_under_test)
-        await ops_test.model.applications[app_name].refresh(
-            path=charm_under_test, resources=resources
-        )
-        await ops_test.model.wait_for_idle(apps=[app_name], status="active", timeout=1000)
-        assert await is_alertmanager_up(ops_test, app_name)
+@pytest.mark.abort_on_fail
+async def test_upgrade_local_with_local_with_relations(ops_test: OpsTest, charm_under_test):
+    # Deploy related apps
+    await asyncio.gather(
+        ops_test.model.deploy("ch:prometheus-k8s", application_name="prom", channel="edge"),
+        ops_test.model.deploy("ch:karma-k8s", application_name="karma", channel="edge"),
+    )
+
+    # Relate apps
+    await asyncio.gather(
+        ops_test.model.add_relation(app_name, "prom"),
+        ops_test.model.add_relation(app_name, "karma"),
+    )
+
+    # Refresh from path
+    await ops_test.model.applications[app_name].refresh(path=charm_under_test, resources=resources)
+    await ops_test.model.wait_for_idle(
+        apps=[app_name, "prom", "karma"], status="active", timeout=1000
+    )
+    assert await is_alertmanager_up(ops_test, app_name)
+
+
+@pytest.mark.abort_on_fail
+async def test_upgrade_with_multiple_units(ops_test: OpsTest, charm_under_test):
+    # Add unit
+    await ops_test.model.applications[app_name].add_units(count=1)
+    await ops_test.model.wait_for_idle(
+        apps=[app_name, "prom", "karma"], status="active", timeout=1000
+    )
+
+    # Refresh from path
+    await ops_test.model.applications[app_name].refresh(path=charm_under_test, resources=resources)
+    await ops_test.model.wait_for_idle(
+        apps=[app_name, "prom", "karma"], status="active", timeout=1000
+    )
+    assert await is_alertmanager_up(ops_test, app_name)


### PR DESCRIPTION
This PR adds the following integration tests:
- remove related relation, then re-relate
- remove related app, then re-relate
- upgrade charm in the presence of relations
- upgrade multi-unit charm

Related: https://github.com/canonical/cos-lite-bundle/pull/22

Crossref: OPENG-687