### PR TITLE
add release automation

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -1,8 +1,5 @@
-name: Run-Tests
+name: Pull Request
 on:
-  push:
-    branches:
-      - main
   pull_request:
     branches:
       - main

--- a/.github/workflows/release-edge.yaml
+++ b/.github/workflows/release-edge.yaml
@@ -1,0 +1,92 @@
+name: Release to Edge
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  lib-check:
+    name: Static analysis of /lib for Python 3.5
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Set up Python 3.5
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.5
+    - name: Install dependencies
+      run: python3 -m pip install tox
+    - name: Run static analysis for /lib for 3.5
+      run: tox -vve static-lib
+  static-analysis:
+    name: Static analysis
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Install dependencies
+      run: python3 -m pip install tox
+    - name: Run static analysis (charm)
+      run: tox -vve static-charm
+    - name: Run static analysis (unit tests)
+      run: tox -vve static-unit
+    - name: Run static analysis (integration tests)
+      run: tox -vve static-integration
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Install dependencies
+      run: python3 -m pip install tox
+    - name: Run linters
+      run: tox -vve lint
+  unit-test:
+    name: Unit tests
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Install dependencies
+      run: python -m pip install tox
+    - name: Run tests
+      run: tox -vve unit
+  integration-test:
+    name: Integration tests (microk8s)
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Setup operator environment
+      uses: charmed-kubernetes/actions-operator@main
+      with:
+        provider: microk8s
+    - name: Run alertmanger tests
+      run: tox -vve integration
+    - name: Run lma bundle tests
+      run: tox -vve integration-lma
+  release-to-charmhub:
+    name: Release to CharmHub
+    needs: 
+      - static-analysis
+      - lib-check
+      - lint
+      - unit-test
+      - integration-test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Select charmhub channel
+        uses: canonical/charming-actions/channel@1.0.0
+        id: channel
+      - name: Upload charm to charmhub
+        uses: canonical/charming-actions/upload-charm@1.0.0
+        with:
+          credentials: "${{ secrets.CHARMHUB_TOKEN }}"
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          channel: "${{ steps.channel.outputs.name }}"


### PR DESCRIPTION
Splits the CI into two workflows. `Release to edge` will use the `charming-actions` to release to edge on charmhub.