### PR TITLE
Replace bind_address with fqdn

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -65,5 +65,3 @@ jobs:
         provider: microk8s
     - name: Run alertmanger tests
       run: tox -vve integration
-    - name: Run lma bundle tests
-      run: tox -vve integration-lma

--- a/.github/workflows/release-edge.yaml
+++ b/.github/workflows/release-edge.yaml
@@ -65,11 +65,9 @@ jobs:
         provider: microk8s
     - name: Run alertmanger tests
       run: tox -vve integration
-    - name: Run lma bundle tests
-      run: tox -vve integration-lma
   release-to-charmhub:
     name: Release to CharmHub
-    needs: 
+    needs:
       - static-analysis
       - lib-check
       - lint

--- a/lib/charms/alertmanager_k8s/v0/alertmanager_dispatch.py
+++ b/lib/charms/alertmanager_k8s/v0/alertmanager_dispatch.py
@@ -25,6 +25,7 @@ class SomeApplication(CharmBase):
 ```
 """
 import logging
+import socket
 from typing import List
 
 import ops
@@ -40,7 +41,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 3
+LIBPATCH = 4
 
 # Set to match metadata.yaml
 INTERFACE_NAME = "alertmanager_dispatch"
@@ -258,9 +259,7 @@ class AlertmanagerProvider(RelationManagerBase):
 
     def _generate_relation_data(self, relation: Relation):
         """Helper function to generate relation data in the correct format."""
-        public_address = "{}:{}".format(
-            self.charm.model.get_binding(relation).network.bind_address, self.api_port
-        )
+        public_address = "{}:{}".format(socket.getfqdn(), self.api_port)
         return {"public_address": public_address}
 
     def update_relation_data(self, event: RelationEvent = None):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # Copyright 2021 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-git+https://github.com/canonical/operator/#egg=ops
+ops
 PyYAML
 lightkube
 lightkube-models

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -60,30 +60,6 @@ async def cli_upgrade_from_path_and_wait(
     await ops_test.model.wait_for_idle(apps=[alias], status=wait_for_status, timeout=120)
 
 
-class IPAddressWorkaround:
-    """Context manager for deploying a charm that needs to have its IP address.
-
-    Due to a juju bug, occasionally some charms finish a startup sequence without
-    having an ip address returned by `bind_address`.
-    https://bugs.launchpad.net/juju/+bug/1929364
-    Issuing dummy update_status just to trigger an event, and then restore it.
-    """
-
-    def __init__(self, ops_test: OpsTest):
-        self.ops_test = ops_test
-
-    async def __aenter__(self):
-        """On entry, the update status interval is set to the minimum 10s."""
-        config = await self.ops_test.model.get_config()
-        self.revert_to = config["update-status-hook-interval"]
-        await self.ops_test.model.set_config({"update-status-hook-interval": "10s"})
-        return self
-
-    async def __aexit__(self, exc_type, exc_value, exc_traceback):
-        """On exit, the update status interval is reverted to its original value."""
-        await self.ops_test.model.set_config({"update-status-hook-interval": self.revert_to})
-
-
 async def get_leader_unit_num(ops_test: OpsTest, app_name: str):
     units = ops_test.model.applications[app_name].units
     is_leader = [await units[i].is_leader_from_status() for i in range(len(units))]

--- a/tests/integration/test_config_changed_modifies_file.py
+++ b/tests/integration/test_config_changed_modifies_file.py
@@ -14,7 +14,7 @@ from pathlib import Path
 
 import pytest
 import yaml
-from helpers import IPAddressWorkaround, get_unit_address, is_alertmanager_up
+from helpers import get_unit_address, is_alertmanager_up
 from pytest_operator.plugin import OpsTest
 
 from alertmanager_client import Alertmanager
@@ -34,10 +34,7 @@ async def test_build_and_deploy(ops_test: OpsTest, charm_under_test):
     """
     # deploy charm from local source folder
     await ops_test.model.deploy(charm_under_test, resources=resources, application_name=app_name)
-
-    async with IPAddressWorkaround(ops_test):
-        await ops_test.model.wait_for_idle(apps=[app_name], status="active", timeout=1000)
-
+    await ops_test.model.wait_for_idle(apps=[app_name], status="active", timeout=1000)
     assert ops_test.model.applications[app_name].units[0].workload_status == "active"
     assert await is_alertmanager_up(ops_test, app_name)
 

--- a/tests/integration/test_kubectl_delete.py
+++ b/tests/integration/test_kubectl_delete.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 import pytest
 import yaml
-from helpers import IPAddressWorkaround, is_alertmanager_up
+from helpers import is_alertmanager_up
 from pytest_operator.plugin import OpsTest
 
 logger = logging.getLogger(__name__)
@@ -23,12 +23,9 @@ async def test_deploy_from_local_path(ops_test: OpsTest, charm_under_test):
     """Deploy the charm-under-test."""
     logger.debug("deploy local charm")
 
-    async with IPAddressWorkaround(ops_test):
-        await ops_test.model.deploy(
-            charm_under_test, application_name=app_name, resources=resources
-        )
-        await ops_test.model.wait_for_idle(apps=[app_name], status="active", timeout=1000)
-        await is_alertmanager_up(ops_test, app_name)
+    await ops_test.model.deploy(charm_under_test, application_name=app_name, resources=resources)
+    await ops_test.model.wait_for_idle(apps=[app_name], status="active", timeout=1000)
+    await is_alertmanager_up(ops_test, app_name)
 
 
 @pytest.mark.abort_on_fail

--- a/tests/unit/charm/test_push_config_to_workload_on_startup.py
+++ b/tests/unit/charm/test_push_config_to_workload_on_startup.py
@@ -9,7 +9,7 @@ from unittest.mock import patch
 import hypothesis.strategies as st
 import validators
 import yaml
-from helpers import patch_network_get, tautology
+from helpers import tautology
 from hypothesis import given
 from ops.testing import Harness
 
@@ -24,7 +24,6 @@ class TestPushConfigToWorkloadOnStartup(unittest.TestCase):
     Background: Charm starts up with initial hooks.
     """
 
-    @patch_network_get(private_address="1.1.1.1")
     @patch.object(Alertmanager, "reload", tautology)
     @patch("charm.KubernetesServicePatch", lambda *a, **kw: None)
     def setUp(self, *_):

--- a/tests/unit/helpers.py
+++ b/tests/unit/helpers.py
@@ -4,31 +4,6 @@
 
 """Helper functions for writing tests."""
 
-from typing import Callable
-from unittest.mock import patch
-
-
-def patch_network_get(private_address="10.1.157.116") -> Callable:
-    def network_get(*args, **kwargs) -> dict:
-        """Patch for the not-yet-implemented testing backend needed for `bind_address`.
-
-        This patch decorator can be used for cases such as:
-        self.model.get_binding(event.relation).network.bind_address
-        """
-        return {
-            "bind-addresses": [
-                {
-                    "mac-address": "",
-                    "interface-name": "",
-                    "addresses": [{"hostname": "", "value": private_address, "cidr": ""}],
-                }
-            ],
-            "egress-subnets": ["10.152.183.65/32"],
-            "ingress-addresses": ["10.152.183.65"],
-        }
-
-    return patch("ops.testing._TestingModelBackend.network_get", network_get)
-
 
 def no_op(*args, **kwargs) -> None:
     pass

--- a/tox.ini
+++ b/tox.ini
@@ -107,11 +107,11 @@ deps =
 commands =
     pytest -v --tb native --log-cli-level=INFO -s {posargs} {toxinidir}/tests/integration
 
-[testenv:integration-lma]
-description = Run lma bundle integration tests but with alertmanager built from source
-lma_bundle_dir = {envtmpdir}/lma-light-bundle
+[testenv:integration-bundle]
+description = Run cos-lite bundle integration tests but with alertmanager built from source
+bundle_dir = {envtmpdir}/cos-lite-bundle
 deps =
-    # deps from lma-bundle - these are needed here because will be running pytest on lma-bundle
+    # deps from cos-lite bundle - these are needed here because running pytest on the bundle
     jinja2
     #git+https://github.com/juju/python-libjuju.git
     juju
@@ -121,7 +121,7 @@ deps =
 allowlist_externals =
     git
 commands =
-    git clone --single-branch --depth=1 https://github.com/canonical/lma-light-bundle.git {[testenv:integration-lma]lma_bundle_dir}
-    # run pytest on the integration tests of the lma bundle, but override alertmanager with path to
-    # this source dir
-    pytest -v --tb native --log-cli-level=INFO -s --alertmanager={toxinidir} {posargs} {[testenv:integration-lma]lma_bundle_dir}/tests/integration
+    git clone --single-branch --depth=1 https://github.com/canonical/cos-light-bundle.git {[testenv:integration-bundle]bundle_dir}
+    # run pytest on the integration tests of the cos-lite bundle, but override alertmanager with
+    # path to this source dir
+    pytest -v --tb native --log-cli-level=INFO -s --alertmanager={toxinidir} {posargs} {[testenv:integration-bundle]bundle_dir}/tests/integration


### PR DESCRIPTION
## Issue
`bind_address` sometimes returns None. Recently observed during load test.

Crossref: [OPENG-785](https://warthogs.atlassian.net/browse/OPENG-785)


## Solution
Use `socket.getfqdn` instead of `bind_address`.


## Context
NTA


## Testing Instructions
Run integration tests.


## Release Notes
Replace bind_address with fqdn.