### PR TITLE
Updated to latest rock

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -29,7 +29,7 @@ resources:
   alertmanager-image:
     type: oci-image
     description: OCI image for alertmanager
-    upstream-source: ubuntu/prometheus-alertmanager:0.21-20.04_beta
+    upstream-source: ubuntu/prometheus-alertmanager:0.23-22.04_beta
 provides:
   alerting:
     # The provider (alertmanager) adds the following key-value pair to the relation data bag of


### PR DESCRIPTION
The latest rock for alertmanager is 0.23-22.04_beta. This commit
updates the upstream source in metadata.yaml to reflect this fact.
This ensures that test runners in github will use this latest rock.
A release to charm hub with an updated oci resource will follow.