### PR TITLE
Integration test for templated notification by receiver

### DIFF
--- a/src/alertmanager_client.py
+++ b/src/alertmanager_client.py
@@ -156,7 +156,9 @@ class Alertmanager:
         except yaml.YAMLError as e:
             raise AlertmanagerBadResponse("Response is not a YAML string") from e
 
-    def _post(self, url, post_data, headers=None, timeout=None) -> bytes:
+    def _post(
+        self, url: str, post_data: bytes, headers: dict = None, timeout: int = None
+    ) -> bytes:
         """Make a HTTP POST request to Alertmanager.
 
         Args:
@@ -186,7 +188,7 @@ class Alertmanager:
             logger.debug("Request timeout during posting to URL %s", url)
         return response
 
-    def set_alerts(self, alerts) -> bytes:
+    def set_alerts(self, alerts: list) -> bytes:
         """Send a set of new alerts to alertmanger.
 
         Args:

--- a/src/alertmanager_client.py
+++ b/src/alertmanager_client.py
@@ -171,7 +171,7 @@ class Alertmanager:
             urllib response object.
         """
         response = "".encode("utf-8")
-        timeout = timeout if timeout else self.timeout
+        timeout = timeout or self.timeout
         request = urllib.request.Request(url, headers=headers or {}, data=post_data, method="POST")
 
         try:

--- a/src/charm.py
+++ b/src/charm.py
@@ -271,7 +271,7 @@ class AlertmanagerCharm(CharmBase):
 
         # add templates, if any
         if templates := self.config["templates_file"]:
-            config["templates"] = [f"'{self._templates_path}'"]
+            config["templates"] = [f"{self._templates_path}"]
             self.container.push(self._templates_path, templates, make_dirs=True)
 
         # add juju topology to "group_by"

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -2,10 +2,13 @@
 # Copyright 2021 Canonical Ltd.
 # See LICENSE file for licensing details.
 
+import socket
 from pathlib import Path
 
 import pytest
 from pytest_operator.plugin import OpsTest
+
+PYTEST_HTTP_SERVER_PORT = 8000
 
 
 @pytest.fixture(scope="module")
@@ -14,3 +17,18 @@ async def charm_under_test(ops_test: OpsTest) -> Path:
     path_to_built_charm = await ops_test.build_charm(".")
 
     return path_to_built_charm
+
+
+@pytest.fixture(scope="session")
+def httpserver_listen_address():
+    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    s.settimeout(0)
+    try:
+        # ip address does not need to be reachable
+        s.connect(("8.8.8.8", 1))
+        local_ip_address = s.getsockname()[0]
+    except Exception:
+        local_ip_address = "127.0.0.1"
+    finally:
+        s.close()
+    return (local_ip_address, PYTEST_HTTP_SERVER_PORT)

--- a/tests/integration/test_templates.py
+++ b/tests/integration/test_templates.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+# Copyright 2022 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import json
+import logging
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+import yaml
+from helpers import get_unit_address, is_alertmanager_up
+from pytest_operator.plugin import OpsTest
+from werkzeug.wrappers import Request, Response
+
+from alertmanager_client import Alertmanager
+
+logger = logging.getLogger(__name__)
+
+METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
+app_name = METADATA["name"]
+resources = {"alertmanager-image": METADATA["resources"]["alertmanager-image"]["upstream-source"]}
+
+
+def request_handler(request: Request):
+    response = Response("OK", status=200, content_type="text/plain")
+    logger.info("Got Request Data : %s", json.loads(request.data.decode("utf-8")))
+    return response
+
+
+@pytest.mark.abort_on_fail
+async def test_receiver_gets_alert(ops_test: OpsTest, charm_under_test, httpserver):
+
+    # deploy charm from local source folder
+    await ops_test.model.deploy(charm_under_test, resources=resources, application_name=app_name)
+    await ops_test.model.wait_for_idle(apps=[app_name], status="active", timeout=1000)
+    assert ops_test.model.applications[app_name].units[0].workload_status == "active"
+    assert await is_alertmanager_up(ops_test, app_name)
+
+    # define the alertmanager configuration
+    receiver_name = "fake-receiver"
+    aconfig = {
+        "global": {"http_config": {"tls_config": {"insecure_skip_verify": True}}},
+        "route": {
+            "group_by": ["alertname"],
+            "group_wait": "3s",
+            "group_interval": "5m",
+            "repeat_interval": "1h",
+            "receiver": receiver_name,
+        },
+        "receivers": [
+            {
+                "name": receiver_name,
+                "slack_configs": [
+                    {
+                        "api_url": httpserver.url_for("/"),
+                        "channel": "test",
+                        "text": r"https://localhost/alerts/{{ .GroupLabels.alertname }}",
+                    }
+                ],
+            }
+        ],
+    }
+
+    # use a template to define the slack callback id
+    atemplate = r'{{ define "slack.default.callbackid" }}2{{ end }}'
+    # set alertmanager configuration and template file
+    await ops_test.model.applications[app_name].set_config(
+        {"config_file": yaml.safe_dump(aconfig), "templates_file": atemplate}
+    )
+    await ops_test.model.wait_for_idle(apps=[app_name], status="active", timeout=60)
+
+    # create an alert
+    start_time = datetime.now(timezone.utc)
+    end_time = start_time + timedelta(minutes=5)
+    alert_name = "fake-alert"
+    model_uuid = "1234"
+    alerts = [
+        {
+            "startsAt": start_time.isoformat("T"),
+            "endsAt": end_time.isoformat("T"),
+            "status": "firing",
+            "annotations": {
+                "summary": "A fake alert",
+            },
+            "labels": {
+                "juju_model_uuid": model_uuid,
+                "juju_application": app_name,
+                "juju_model": ops_test.model_name,
+                "alertname": alert_name,
+            },
+            "generatorURL": f"http://localhost/{alert_name}",
+        }
+    ]
+
+    # define the expected slack notification for the alert
+    expected_notification = {
+        "channel": "test",
+        "username": "Alertmanager",
+        "attachments": [
+            {
+                "title": f"[FIRING:1] {alert_name} {app_name} {ops_test.model_name} {model_uuid} ",
+                "title_link": f"http://{app_name}-0:9093/#/alerts?receiver={receiver_name}",
+                "text": f"https://localhost/alerts/{alert_name}",
+                "fallback": f"[FIRING:1] {alert_name} {app_name} {ops_test.model_name} {model_uuid}  | "
+                f"http://{app_name}-0:9093/#/alerts?receiver={receiver_name}",
+                "callback_id": "2",
+                "footer": "",
+                "color": "danger",
+                "mrkdwn_in": ["fallback", "pretext", "text"],
+            }
+        ],
+    }
+
+    # set the alert
+    with httpserver.wait(timeout=120) as waiting:
+        # expect an alert to be forwarded to the receiver
+        httpserver.expect_oneshot_request(
+            "/", method="POST", json=expected_notification
+        ).respond_with_handler(request_handler)
+        client_address = await get_unit_address(ops_test, app_name, 0)
+        amanager = Alertmanager(address=client_address)
+        amanager.set_alerts(alerts)
+
+    # check receiver got an alert
+    assert waiting.result

--- a/tests/unit/test_alertmanager_client.py
+++ b/tests/unit/test_alertmanager_client.py
@@ -4,6 +4,7 @@
 
 import json
 import unittest
+from datetime import datetime
 from unittest.mock import patch
 
 from alertmanager_client import Alertmanager, AlertmanagerBadResponse
@@ -59,3 +60,23 @@ class TestAlertmanagerAPIClient(unittest.TestCase):
         urlopen_mock.return_value.reason = "OK"
 
         self.assertEqual(self.api.version, "0.1.2")
+
+    @patch("alertmanager_client.urllib.request.urlopen")
+    def test_alerts_can_be_set(self, urlopen_mock):
+        msg = "HTTP 200 OK"
+        urlopen_mock.return_value = msg
+        alerts = [
+            {
+                "startsAt": datetime.now().isoformat("T"),
+                "status": "firing",
+                "annotations": {
+                    "summary": "A fake alert",
+                },
+                "labels": {
+                    "alertname": "fake alert",
+                },
+            }
+        ]
+        status = self.api.set_alerts(alerts)
+        urlopen_mock.assert_called()
+        self.assertEqual(status, msg)

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -115,7 +115,7 @@ class TestWithInitialHooks(unittest.TestCase):
         updated_config = yaml.safe_load(
             self.harness.charm.container.pull(self.harness.charm._config_path)
         )
-        self.assertEqual(updated_config["templates"], [f"'{self.harness.charm._templates_path}'"])
+        self.assertEqual(updated_config["templates"], [f"{self.harness.charm._templates_path}"])
 
 
 class TestWithoutInitialHooks(unittest.TestCase):

--- a/tox.ini
+++ b/tox.ini
@@ -104,6 +104,7 @@ deps =
     pytest
     #git+https://github.com/charmed-kubernetes/pytest-operator.git
     pytest-operator
+    pytest-httpserver
 commands =
     pytest -v --tb native --log-cli-level=INFO -s {posargs} {toxinidir}/tests/integration
 


### PR DESCRIPTION
This pull request
1. Adds an integration test to check that notifications sent to alert receivers can be customized using the Alertmanger charms template file configuration option.
2. Fixes a bug in specifying the template file path in the Alertmanager configuration file that prevented templates from working.
3. Enhances the Alertmanager client object by adding an API to set alerts.
4. Adds a unit tests for the newly added set alert API.

Closes #40