### PR TITLE
Integration test for persistence of silences

### DIFF
--- a/tests/integration/test_persistence.py
+++ b/tests/integration/test_persistence.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+# Copyright 2022 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import logging
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+import yaml
+from helpers import get_unit_address, is_alertmanager_up
+from pytest_operator.plugin import OpsTest
+
+from alertmanager_client import Alertmanager
+
+logger = logging.getLogger(__name__)
+
+METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
+app_name = METADATA["name"]
+resources = {"alertmanager-image": METADATA["resources"]["alertmanager-image"]["upstream-source"]}
+
+
+@pytest.mark.abort_on_fail
+async def test_silences_persist_across_upgrades(ops_test: OpsTest, charm_under_test, httpserver):
+    # deploy alertmanager charm from charmhub
+    logger.info("deploy charm from charmhub")
+    await ops_test.model.deploy("ch:alertmanager-k8s", application_name=app_name, channel="edge")
+    await ops_test.model.wait_for_idle(apps=[app_name], status="active", timeout=1000)
+
+    # set a silencer for an alert and check it is set
+    alertmanager = Alertmanager(address=await get_unit_address(ops_test, app_name, 0))
+
+    silence_start = datetime.now(timezone.utc)
+    silence_end = silence_start + timedelta(minutes=30)
+    matchers = [
+        {
+            "name": "alertname",
+            "value": "fake-alert",
+            "isRegex": False,
+        }
+    ]
+    alertmanager.set_silences(matchers, silence_start, silence_end)
+    silences_before = alertmanager.get_silences()
+    assert len(silences_before)
+
+    # upgrade alertmanger using charm built locally
+    logger.info("upgrade deployed charm with local charm %s", charm_under_test)
+    await ops_test.model.applications[app_name].refresh(path=charm_under_test, resources=resources)
+    await ops_test.model.wait_for_idle(apps=[app_name], status="active", timeout=1000)
+    assert await is_alertmanager_up(ops_test, app_name)
+
+    # check silencer is still set
+    alertmanager = Alertmanager(address=await get_unit_address(ops_test, app_name, 0))
+    silences_after = alertmanager.get_silences()
+    assert len(silences_after)
+
+    assert silences_before == silences_after

--- a/tests/integration/test_persistence.py
+++ b/tests/integration/test_persistence.py
@@ -43,6 +43,43 @@ async def test_silences_persist_across_upgrades(ops_test: OpsTest, charm_under_t
     silences_before = alertmanager.get_silences()
     assert len(silences_before)
 
+    # Use kubectl to send a SIGTERM signal to Alertmanager so that data is flushed to disk.
+    # This step should not be necessary once the bug in the following issue ticket is fixed
+    # https://github.com/canonical/pebble/issues/122
+    # FIXME: remove the following kubectl commands once the above bug is fixed
+    pod_name = f"{app_name}-0"
+    container_name = "alertmanager"
+    sg_cmd = [
+        "sg",
+        "microk8s",
+        "-c",
+    ]
+    kubectl_cmd = [
+        "microk8s.kubectl",
+        "-n",
+        ops_test.model_name,
+        "exec",
+        pod_name,
+        "-c",
+        container_name,
+        "--",
+    ]
+    # find pid of alertmanager
+    pid_cmd = ["pidof", "alertmanager"]
+    cmd = sg_cmd + [" ".join(kubectl_cmd + pid_cmd)]
+    retcode, alertmanager_pid, stderr = await ops_test.run(*cmd)
+    assert retcode == 0, f"kubectl failed: {(stderr or alertmanager_pid).strip()}"
+    # use pid of alertmanager to send it a SIGTERM signal using kubectl
+    term_cmd = ["kill", "-s", "TERM", alertmanager_pid]
+    cmd = sg_cmd + [" ".join(kubectl_cmd + term_cmd)]
+    logger.debug("Sending SIGTERM to Alertmanager")
+    retcode, stdout, stderr = await ops_test.run(*cmd)
+    assert retcode == 0, f"kubectl failed: {(stderr or stdout).strip()}"
+    logger.debug(stdout)
+    await ops_test.model.block_until(lambda: len(ops_test.model.applications[app_name].units) > 0)
+    await ops_test.model.wait_for_idle(apps=[app_name], status="active", timeout=1000)
+    assert await is_alertmanager_up(ops_test, app_name)
+
     # upgrade alertmanger using charm built locally
     logger.info("upgrade deployed charm with local charm %s", charm_under_test)
     await ops_test.model.applications[app_name].refresh(path=charm_under_test, resources=resources)

--- a/tests/unit/test_alertmanager_client.py
+++ b/tests/unit/test_alertmanager_client.py
@@ -4,7 +4,7 @@
 
 import json
 import unittest
-from datetime import datetime
+from datetime import datetime, timedelta, timezone
 from unittest.mock import patch
 
 from alertmanager_client import Alertmanager, AlertmanagerBadResponse
@@ -78,5 +78,72 @@ class TestAlertmanagerAPIClient(unittest.TestCase):
             }
         ]
         status = self.api.set_alerts(alerts)
+        urlopen_mock.assert_called()
+        self.assertEqual(status, msg)
+
+    @patch("alertmanager_client.urllib.request.urlopen")
+    def test_available_alerts_are_returned(self, urlopen_mock):
+        fake_alerts = [
+            {
+                "labels": {"name": "fake-alert"},
+                "startsAt": datetime.now().isoformat("T"),
+            }
+        ]
+        urlopen_mock.return_value.read = lambda: json.dumps(fake_alerts)
+        urlopen_mock.return_value.code = 200
+        urlopen_mock.return_value.reason = "OK"
+
+        alerts = self.api.get_alerts()
+        self.assertListEqual(alerts, fake_alerts)
+
+    @patch("alertmanager_client.urllib.request.urlopen")
+    def test_silences_can_be_set(self, urlopen_mock):
+        msg = "HTTP 200 OK"
+        urlopen_mock.return_value = msg
+        matchers = [
+            {
+                "name": "alertname",
+                "value": "fake-alert",
+                "isRegex": False,
+            }
+        ]
+        silence_start = datetime.now(timezone.utc)
+        silence_end = silence_start + timedelta(minutes=60)
+        status = self.api.set_silences(
+            matchers=matchers, start_time=silence_start, end_time=silence_end
+        )
+        urlopen_mock.assert_called()
+        self.assertEqual(status, msg)
+
+    @patch("alertmanager_client.urllib.request.urlopen")
+    def test_available_silences_are_returned(self, urlopen_mock):
+        fake_silences = [
+            {
+                "id": "fake-silencer",
+                "status": {"state": "active"},
+                "startsAt": datetime.now().isoformat("T"),
+                "endsAt": (datetime.now() + timedelta(minutes=60)).isoformat("T"),
+                "matchers": [
+                    {
+                        "name": "alertname",
+                        "value": "fake-alert",
+                        "isRegex": False,
+                    }
+                ],
+            }
+        ]
+        urlopen_mock.return_value.read = lambda: json.dumps(fake_silences)
+        urlopen_mock.return_value.code = 200
+        urlopen_mock.return_value.reason = "OK"
+
+        alerts = self.api.get_silences()
+        self.assertListEqual(alerts, fake_silences)
+
+    @patch("alertmanager_client.urllib.request.urlopen")
+    def test_silences_can_be_deleted(self, urlopen_mock):
+        msg = "HTTP 200 OK"
+        urlopen_mock.return_value = msg
+
+        status = self.api.delete_silence("fake-id")
         urlopen_mock.assert_called()
         self.assertEqual(status, msg)


### PR DESCRIPTION
This PR adds an integration test for persistence of silences and hence also tests data persistence because silences are stored in the Alertmanager k8s charm's persistence volume claim. As part of the PR the Alertmanager client object is also enhanced to set, get and delete silences.