### PR TITLE
Use compute resource patch to limit resources

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -64,6 +64,7 @@ jobs:
       with:
         juju-channel: latest/stable
         provider: microk8s
+        channel: edge
         bootstrap-options: "--agent-version 2.9.29"
     - name: Run alertmanger tests
       run: tox -vve integration

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -66,5 +66,8 @@ jobs:
         provider: microk8s
         channel: edge
         bootstrap-options: "--agent-version 2.9.29"
+    - name: Patch hostpath-provisioner
+      run: >
+        sg microk8s -c "kubectl patch deployment hostpath-provisioner -n kube-system -p '{\"spec\": {\"template\": {\"spec\": {\"containers\": [{\"name\":\"hostpath-provisioner\", \"image\": \"cdkbot/hostpath-provisioner:1.3.0\" }] }}}}'"
     - name: Run alertmanger tests
       run: tox -vve integration

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -62,6 +62,8 @@ jobs:
     - name: Setup operator environment
       uses: charmed-kubernetes/actions-operator@main
       with:
+        juju-channel: latest/stable
         provider: microk8s
+        bootstrap-options: "--agent-version 2.9.29"
     - name: Run alertmanger tests
       run: tox -vve integration

--- a/.github/workflows/release-edge.yaml
+++ b/.github/workflows/release-edge.yaml
@@ -62,7 +62,9 @@ jobs:
     - name: Setup operator environment
       uses: charmed-kubernetes/actions-operator@main
       with:
+        juju-channel: latest/stable
         provider: microk8s
+        bootstrap-options: "--agent-version 2.9.29"
     - name: Run alertmanger tests
       run: tox -vve integration
   release-to-charmhub:

--- a/.github/workflows/release-edge.yaml
+++ b/.github/workflows/release-edge.yaml
@@ -82,10 +82,10 @@ jobs:
         with:
           fetch-depth: 0
       - name: Select charmhub channel
-        uses: canonical/charming-actions/channel@1.0.0
+        uses: canonical/charming-actions/channel@2.0.0-rc
         id: channel
       - name: Upload charm to charmhub
-        uses: canonical/charming-actions/upload-charm@1.0.0
+        uses: canonical/charming-actions/upload-charm@2.0.0-rc
         with:
           credentials: "${{ secrets.CHARMHUB_TOKEN }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/config.yaml
+++ b/config.yaml
@@ -39,3 +39,17 @@ options:
       host or a bare A record, this may be omitted.
       If the URL has a path portion, Alertmanager will use it to prefix all HTTP
       endpoints.
+  cpu:
+    description: |
+      K8s cpu resource limit, e.g. "1" or "500m". Default is unset (no limit). This value is used
+      for the "limits" portion of the resource requirements (the "requests" portion is
+      automatically deduced from it).
+      See https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+    type: string
+  memory:
+    description: |
+      K8s memory resource limit, e.g. "1Gi". Default is unset (no limit). This value is used
+      for the "limits" portion of the resource requirements (the "requests" portion is
+      automatically deduced from it).
+      See https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+    type: string

--- a/lib/charms/observability_libs/v0/kubernetes_compute_resources_patch.py
+++ b/lib/charms/observability_libs/v0/kubernetes_compute_resources_patch.py
@@ -1,0 +1,620 @@
+# Copyright 2022 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""# KubernetesComputeResourcesPatch Library.
+
+This library is designed to enable developers to more simply patch the Kubernetes compute resource
+limits and requests created by Juju during the deployment of a sidecar charm.
+
+When initialised, this library binds a handler to the parent charm's `config-changed` event.
+The config-changed event is used because it is guaranteed to fire on startup, on upgrade and on
+pod churn. Additionally, resource limits may be set by charm config options, which would also be
+caught out-of-the-box by this handler. The handler applies the patch to the app's StatefulSet.
+This should ensure that the resource limits are correct throughout the charm's life.Additional
+optional user-provided events for re-applying the patch are supported but discouraged.
+
+The constructor takes a reference to the parent charm, a 'limits' and a 'requests' dictionaries
+that together define the resource requirements. For information regarding the `lightkube`
+`ResourceRequirements` model, please visit the `lightkube`
+[docs](https://gtsystem.github.io/lightkube-models/1.23/models/core_v1/#resourcerequirements).
+
+
+## Getting Started
+
+To get started using the library, you just need to fetch the library using `charmcraft`. **Note
+that you also need to add `lightkube` and `lightkube-models` to your charm's `requirements.txt`.**
+
+```shell
+cd some-charm
+charmcraft fetch-lib charms.observability_libs.v0.kubernetes_compute_resources_patch
+cat << EOF >> requirements.txt
+lightkube
+lightkube-models
+EOF
+```
+
+Then, to initialise the library:
+
+```python
+# ...
+from charms.observability_libs.v0.kubernetes_compute_resources_patch import (
+    KubernetesComputeResourcesPatch
+)
+
+class SomeCharm(CharmBase):
+  def __init__(self, *args):
+    # ...
+    self.resources_patch = KubernetesComputeResourcesPatch(
+        self,
+        "container-name",
+        limits_func=lambda: {"cpu": "1", "mem": "2Gi"},
+        requests_func=lambda: {"cpu": "1", "mem": "2Gi"}
+    )
+    # ...
+```
+
+Or, if, for example, the resource specs are coming from config options:
+
+```python
+# ...
+
+class SomeCharm(CharmBase):
+  def __init__(self, *args):
+    # ...
+    self.resources_patch = KubernetesComputeResourcesPatch(
+        self,
+        "container-name",
+        limits_func=lambda: self._resource_spec_from_config(),
+        requests_func=lambda: self._resource_spec_from_config(),
+    )
+
+  def _resource_spec_from_config(self):
+    return {"cpu": self.model.config.get("cpu"), "memory": self.model.config.get("memory")}
+
+    # ...
+```
+
+
+Additionally, you may wish to use mocks in your charm's unit testing to ensure that the library
+does not try to make any API calls, or open any files during testing that are unlikely to be
+present, and could break your tests. The easiest way to do this is during your test `setUp`:
+
+```python
+# ...
+
+@patch.multiple(
+    "charm.KubernetesComputeResourcesPatch",
+    _namespace="test-namespace",
+    _is_patched=lambda *a, **kw: True,
+    is_ready=lambda *a, **kw: True,
+)
+@patch("lightkube.core.client.GenericSyncClient")
+def setUp(self, *unused):
+    self.harness = Harness(SomeCharm)
+    # ...
+```
+"""
+import decimal
+import logging
+from decimal import Decimal
+from math import ceil, floor
+from typing import Callable, Dict, List, Optional, TypedDict, Union
+
+from lightkube import ApiError, Client
+from lightkube.core import exceptions
+from lightkube.models.apps_v1 import StatefulSetSpec
+from lightkube.models.core_v1 import (
+    Container,
+    PodSpec,
+    PodTemplateSpec,
+    ResourceRequirements,
+)
+from lightkube.resources.apps_v1 import StatefulSet
+from lightkube.resources.core_v1 import Pod
+from lightkube.types import PatchType
+from lightkube.utils.quantity import equals_canonically, parse_quantity
+from ops.charm import CharmBase
+from ops.framework import BoundEvent, EventBase, EventSource, Object, ObjectEvents
+
+logger = logging.getLogger(__name__)
+
+# The unique Charmhub library identifier, never change it
+LIBID = "2a6066f701444e8db44ba2f6af28da90"
+
+# Increment this major API version when introducing breaking changes
+LIBAPI = 0
+
+# Increment this PATCH version before using `charmcraft publish-lib` or reset
+# to 0 if you are raising the major API version
+LIBPATCH = 1
+
+
+class ResourceSpecDict(TypedDict, total=False):
+    """A dict representing a K8s resource limit.
+
+    See:
+    - https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+    - https://gtsystem.github.io/lightkube-models/1.23/models/core_v1/#resourcerequirements
+    """
+
+    cpu: Optional[str]
+    memory: Optional[str]
+
+
+_Decimal = Union[Decimal, float, str, int]  # types that are potentially convertible to Decimal
+
+
+def ray_hopper(x: _Decimal, a1: _Decimal, a2: _Decimal, x0: _Decimal) -> Decimal:
+    """A monotone ray hopper.
+
+    For example, this could model the thrust of a hypothetical multi-stage rocket engine, as a
+    function of time.
+
+    Args:
+        x: the value for which to calculate the function.
+        a1: the slope of the first ray.
+        a2: the slope of the second ray; must be a1 > a2.
+        x0: the crossover point from the first ray (a1) to the second ray (a2); must be x0 > 0.
+
+    Returns:
+        A linear piecewise-continuous function of x given two "rays", y = a1*x and y = a2*x,
+        and a crossover point x0, as follows:
+        - x, if 0 <= x <= x0;
+        - a1*x, if x0 < x <= a1/a2*x0;
+        - a2*x, if a1/a2*x0 < x.
+
+    >>> ray_hopper(1000, 1, "0.8", 200)  # take 0.8 * 1000
+    Decimal('800.0')
+    >>> ray_hopper(260, 1, "0.8", 200)  # take 0.8 * 260 (input value still > default / 0.8)
+    Decimal('208.0')
+    >>> ray_hopper(250, 1, "0.8", 200)  # take the default, 200 (input value <= default / 0.8)
+    Decimal('200')
+    >>> ray_hopper(200, 1, "0.8", 200)
+    Decimal('200')
+    >>> ray_hopper(150, 1, "0.8", 200)  # return the input value (input value < default)
+    Decimal('150')
+    """
+    try:
+        a1 = Decimal(a1)
+        a2 = Decimal(a2)
+        x = Decimal(x)
+        x0 = Decimal(x0)
+    except ArithmeticError:
+        raise ValueError("Invalid argument(s): all args must be (convertible to) decimal.")
+
+    if any(arg < 0 for arg in [x, a1, a2, x0]):
+        raise ValueError("Invalid argument(s): all args must be greater than 0.")
+    if a1 <= a2:
+        raise ValueError("Invalid argument: must satisfy a1 > a2.")
+
+    if x <= x0:
+        return a1 * x
+
+    a1x0 = a1 * x0
+    if x <= a1x0 / a2:
+        return a1x0
+
+    return a2 * x
+
+
+def limits_to_requests_scaled(
+    resource_limits: ResourceSpecDict, default_requests: ResourceSpecDict, scaling_factor: _Decimal
+) -> ResourceSpecDict:
+    """A helper function for calculating "requests" from a "limits" dict using a scaling factor.
+
+    With this function:
+    - When the "limits" portion is high enough, the "requests" portion is scaled down
+      proportionally, leaving some room for bursts.
+    - When the "limits" portion is too low, no scaling takes place and the requests equals the
+      limits.
+
+    Args:
+        resource_limits: A dictionary representation of K8s resource limits
+        default_requests: The default requests values to use if a limits value is not given. This
+            would also be used as the crossover point from requests = limits to the scaled limits.
+            For example, we can set the "requests" portion of the resource limits to a sensible
+            value, while keeping the "limits" portion unspecified.
+        scaling_factor: A scaling factor used to calculate the requests value from the limits
+            value. The scaling factor must satisfy: 0 < scaling_factor < 1.
+
+    Raises:
+        ValueError, if arguments are invalid or out of range.
+
+    Returns:
+        A resource spec dictionary scaled-down by scaling_factor, subject to the "default value"
+         constraint as described above.
+
+    >>> sf = Decimal("0.8")
+    >>> limits_to_requests_scaled({"cpu": "1"}, {"cpu": "200m"}, sf)
+    {'cpu': '0.800'}
+    >>> limits_to_requests_scaled({"cpu": "260m"}, {"cpu": "200m"}, sf)
+    {'cpu': '0.208'}
+    >>> limits_to_requests_scaled({"cpu": "250m"}, {"cpu": "200m"}, sf)
+    {'cpu': '0.200'}
+    >>> limits_to_requests_scaled({"cpu": "200m"}, {"cpu": "200m"}, sf)
+    {'cpu': '0.200'}
+    >>> limits_to_requests_scaled({"cpu": "150m"}, {"cpu": "200m"}, sf)
+    {'cpu': '0.150'}
+    """
+    scaling_factor = Decimal(scaling_factor)
+    if not (0 < scaling_factor < 1):
+        raise ValueError("scaling_factor must be in the range (0, 1).")
+
+    if not is_valid_spec(resource_limits):
+        raise ValueError("Invalid limits spec: {}".format(resource_limits))
+    if not is_valid_spec(default_requests):
+        raise ValueError("Invalid default requests spec: {}".format(default_requests))
+
+    resource_limits = sanitize_resource_spec_dict(resource_limits) or {}
+    default_requests = sanitize_resource_spec_dict(default_requests) or {}
+
+    # Construct a "requests" dict from a "limits" dict (user input).
+    # Default "requests" values will be used for any missing key in "limits".
+    requests = {}
+    for k in ResourceSpecDict.__annotations__.keys():
+        if k in default_requests:
+            default = parse_quantity(default_requests[k])  # type: ignore[literal-required]
+            value = (
+                ray_hopper(
+                    parse_quantity(resource_limits[k]), Decimal("1.0"), scaling_factor, default  # type: ignore[literal-required, arg-type]
+                )
+                if k in resource_limits
+                else default
+            )
+            requests[k] = str(value.quantize(decimal.Decimal("0.001"), rounding=decimal.ROUND_UP))  # type: ignore[union-attr]
+
+    return ResourceSpecDict(requests)  # type: ignore[misc]
+
+
+def is_valid_spec(spec: Optional[ResourceSpecDict], debug=False) -> bool:  # noqa: C901
+    """Check if the spec dict is valid."""
+    if spec is None:
+        return True
+    if not isinstance(spec, dict):
+        if debug:
+            logger.error("Invalid resource spec type '%s': must be either None or dict.", spec)
+        return False
+
+    for k, v in spec.items():
+        if k not in ResourceSpecDict.__annotations__.keys():
+            if debug:
+                logger.error("Invalid resource spec entry: {%s: %s}.", k, v)
+            return False
+        try:
+            assert isinstance(v, (str, type(None)))  # for type checker
+            pv = parse_quantity(v)
+        except ValueError:
+            if debug:
+                logger.error("Invalid resource spec entry: {%s: %s}.", k, v)
+            return False
+
+        if pv and pv < 0:
+            if debug:
+                logger.error("Invalid resource spec entry: {%s: %s}; must be non-negative.", k, v)
+            return False
+
+    return True
+
+
+def sanitize_resource_spec_dict(spec: Optional[ResourceSpecDict]) -> Optional[ResourceSpecDict]:
+    """Fix spec values without altering semantics.
+
+    The purpose of this helper function is to correct known issues.
+    This function is not intended for fixing user mistakes such as incorrect keys present; that is
+    left for the `is_valid_spec` function.
+    """
+    if not spec:
+        return spec
+
+    d = spec.copy()
+
+    for k, v in spec.items():
+        if not v:
+            # Need to ignore empty values input, otherwise the StatefulSet will have "0" as the
+            # setpoint, the pod will not be scheduled and the charm would be stuck in unknown/lost.
+            # This slightly changes the spec semantics compared to lightkube/k8s: a setpoint of
+            # `None` would be interpreted here as "no limit".
+            del d[k]  # type: ignore
+
+    # Round up memory to whole bytes. This is need to avoid K8s errors such as:
+    # fractional byte value "858993459200m" (0.8Gi) is invalid, must be an integer
+    memory = d.get("memory")
+    if memory:
+        as_decimal = parse_quantity(memory)
+        if as_decimal and as_decimal.remainder_near(floor(as_decimal)):
+            d["memory"] = str(ceil(as_decimal))
+    return d
+
+
+class K8sResourcePatchFailedEvent(EventBase):
+    """Emitted when patching fails."""
+
+    def __init__(self, handle, message=None):
+        super().__init__(handle)
+        self.message = message
+
+    def snapshot(self) -> Dict:
+        """Save grafana source information."""
+        return {"message": self.message}
+
+    def restore(self, snapshot):
+        """Restore grafana source information."""
+        self.message = snapshot["message"]
+
+
+class K8sResourcePatchEvents(ObjectEvents):
+    """Events raised by :class:`K8sResourcePatchEvents`."""
+
+    patch_failed = EventSource(K8sResourcePatchFailedEvent)
+
+
+class ContainerNotFoundError(ValueError):
+    """Raised when a given container does not exist in the list of containers."""
+
+
+class ResourcePatcher:
+    """Helper class for patching a container's resource limits in a given StatefulSet."""
+
+    def __init__(self, namespace: str, statefulset_name: str, container_name: str):
+        self.namespace = namespace
+        self.statefulset_name = statefulset_name
+        self.container_name = container_name
+        self.client = Client()
+
+    def _patched_delta(self, resource_reqs: ResourceRequirements) -> StatefulSet:
+        statefulset = self.client.get(
+            StatefulSet, name=self.statefulset_name, namespace=self.namespace
+        )
+
+        return StatefulSet(
+            spec=StatefulSetSpec(
+                selector=statefulset.spec.selector,  # type: ignore[attr-defined]
+                serviceName=statefulset.spec.serviceName,  # type: ignore[attr-defined]
+                template=PodTemplateSpec(
+                    spec=PodSpec(
+                        containers=[Container(name=self.container_name, resources=resource_reqs)]
+                    )
+                ),
+            )
+        )
+
+    @classmethod
+    def _get_container(cls, container_name: str, containers: List[Container]) -> Container:
+        """Find our container from the container list, assuming list is unique by name.
+
+        Typically, *.spec.containers[0] is the charm container, and [1] is the (only) workload.
+
+        Raises:
+            ContainerNotFoundError, if the user-provided container name does not exist in the list.
+
+        Returns:
+            An instance of :class:`Container` whose name matches the given name.
+        """
+        try:
+            return next(iter(filter(lambda ctr: ctr.name == container_name, containers)))
+        except StopIteration:
+            raise ContainerNotFoundError(f"Container '{container_name}' not found")
+
+    def is_patched(self, resource_reqs: ResourceRequirements) -> bool:
+        """Reports if the resource patch has been applied to the StatefulSet.
+
+        Returns:
+            bool: A boolean indicating if the service patch has been applied.
+        """
+        return equals_canonically(self.get_templated(), resource_reqs)
+
+    def get_templated(self) -> ResourceRequirements:
+        """Returns the resource limits specified in the StatefulSet template."""
+        statefulset = self.client.get(
+            StatefulSet, name=self.statefulset_name, namespace=self.namespace
+        )
+        podspec_tpl = self._get_container(
+            self.container_name,
+            statefulset.spec.template.spec.containers,  # type: ignore[attr-defined]
+        )
+        return podspec_tpl.resources
+
+    def get_actual(self, pod_name: str) -> ResourceRequirements:
+        """Return the resource limits that are in effect for the container in the given pod."""
+        pod = self.client.get(Pod, name=pod_name, namespace=self.namespace)
+        podspec = self._get_container(
+            self.container_name, pod.spec.containers  # type: ignore[attr-defined]
+        )
+        return podspec.resources
+
+    def is_ready(self, pod_name, resource_reqs: ResourceRequirements):
+        """Reports if the resource patch has been applied and is in effect.
+
+        Returns:
+            bool: A boolean indicating if the service patch has been applied and is in effect.
+        """
+        return self.is_patched(resource_reqs) and equals_canonically(
+            resource_reqs, self.get_actual(pod_name)
+        )
+
+    def apply(self, resource_reqs: ResourceRequirements) -> None:
+        """Patch the Kubernetes resources created by Juju to limit cpu or mem."""
+        # Need to ignore invalid input, otherwise the StatefulSet gives "FailedCreate" and the
+        # charm would be stuck in unknown/lost.
+        if self.is_patched(resource_reqs):
+            return
+
+        self.client.patch(
+            StatefulSet,
+            self.statefulset_name,
+            self._patched_delta(resource_reqs),
+            namespace=self.namespace,
+            patch_type=PatchType.APPLY,
+            field_manager=self.__class__.__name__,
+        )
+
+
+class KubernetesComputeResourcesPatch(Object):
+    """A utility for patching the Kubernetes compute resources set up by Juju."""
+
+    on = K8sResourcePatchEvents()
+
+    def __init__(
+        self,
+        charm: CharmBase,
+        container_name: str,
+        *,
+        limits_func: Callable[[], Optional[ResourceSpecDict]],
+        requests_func: Callable[[], Optional[ResourceSpecDict]],
+        refresh_event: Optional[Union[BoundEvent, List[BoundEvent]]] = None,
+    ):
+        """Constructor for KubernetesComputeResourcesPatch.
+
+        References:
+            - https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+
+        Args:
+            charm: the charm that is instantiating the library.
+            container_name: the container for which to apply the resource limits.
+            limits_func: a callable returning a dictionary for `limits` resources; if raises,
+              should only raise ValueError.
+            requests_func: a callable returning a dictionary for `requests` resources; if raises,
+              should only raise ValueError.
+            refresh_event: an optional bound event or list of bound events which
+                will be observed to re-apply the patch.
+        """
+        super().__init__(charm, "{}_{}".format(self.__class__.__name__, container_name))
+        self._charm = charm
+        self._container_name = container_name
+        self.limits_func = limits_func
+        self.requests_func = requests_func
+        self.patcher = ResourcePatcher(self._namespace, self._app, container_name)
+
+        # Ensure this patch is applied during the 'config-changed' event, which is emitted every
+        # startup and every upgrade. The config-changed event is a good time to apply this kind of
+        # patch because it is always emitted after storage-attached, leadership and peer-created,
+        # all of which only fire after install. Patching the statefulset prematurely could result
+        # in those events firing without a workload.
+        self.framework.observe(charm.on.config_changed, self._on_config_changed)
+
+        if not refresh_event:
+            refresh_event = []
+        elif not isinstance(refresh_event, list):
+            refresh_event = [refresh_event]
+        for ev in refresh_event:
+            self.framework.observe(ev, self._on_config_changed)
+
+    def _on_config_changed(self, _):
+        self._patch()
+
+    def _patch(self) -> None:
+        """Patch the Kubernetes resources created by Juju to limit cpu or mem."""
+        try:
+            limits = self.limits_func()
+            requests = self.requests_func()
+        except ValueError as e:
+            msg = f"Failed obtaining resource limit spec: {e}"
+            logger.error(msg)
+            self.on.patch_failed.emit(message=msg)
+            return
+
+        for spec in (limits, requests):
+            if not is_valid_spec(spec):
+                msg = f"Invalid resource limit spec: {spec}"
+                logger.error(msg)
+                self.on.patch_failed.emit(message=msg)
+                return
+
+        resource_reqs = ResourceRequirements(
+            limits=sanitize_resource_spec_dict(limits),  # type: ignore[arg-type]
+            requests=sanitize_resource_spec_dict(requests),  # type: ignore[arg-type]
+        )
+
+        try:
+            self.patcher.apply(resource_reqs)
+
+        except exceptions.ConfigError as e:
+            msg = f"Error creating k8s client: {e}"
+            logger.error(msg)
+            self.on.patch_failed.emit(message=msg)
+            return
+
+        except ApiError as e:
+            if e.status.code == 403:
+                msg = f"Kubernetes resources patch failed: `juju trust` this application. {e}"
+            else:
+                msg = f"Kubernetes resources patch failed: {e}"
+
+            logger.error(msg)
+            self.on.patch_failed.emit(message=msg)
+
+        except ValueError as e:
+            msg = f"Kubernetes resources patch failed: {e}"
+            logger.error(msg)
+            self.on.patch_failed.emit(message=msg)
+
+        else:
+            logger.info(
+                "Kubernetes resources for app '%s', container '%s' patched successfully: %s",
+                self._app,
+                self._container_name,
+                resource_reqs,
+            )
+
+    def is_ready(self) -> bool:
+        """Reports if the resource patch has been applied and is in effect.
+
+        Returns:
+            bool: A boolean indicating if the service patch has been applied and is in effect.
+        """
+        try:
+            limits = self.limits_func()
+            requests = self.requests_func()
+        except ValueError as e:
+            msg = f"Failed obtaining resource limit spec: {e}"
+            logger.error(msg)
+            return False
+
+        if not is_valid_spec(limits) or not is_valid_spec(requests):
+            return False
+
+        resource_reqs = ResourceRequirements(
+            limits=sanitize_resource_spec_dict(limits),  # type: ignore[arg-type]
+            requests=sanitize_resource_spec_dict(requests),  # type: ignore[arg-type]
+        )
+
+        try:
+            return self.patcher.is_ready(self._pod, resource_reqs)
+        except (ValueError, ApiError) as e:
+            msg = f"Failed to apply resource limit patch: {e}"
+            logger.error(msg)
+            self.on.patch_failed.emit(message=msg)
+            return False
+
+    @property
+    def _app(self) -> str:
+        """Name of the current Juju application.
+
+        Returns:
+            str: A string containing the name of the current Juju application.
+        """
+        return self._charm.app.name
+
+    @property
+    def _pod(self) -> str:
+        """Name of the unit's pod.
+
+        Returns:
+            str: A string containing the name of the current unit's pod.
+        """
+        return "-".join(self._charm.unit.name.rsplit("/", 1))
+
+    @property
+    def _namespace(self) -> str:
+        """The Kubernetes namespace we're running in.
+
+        If a charm is deployed into the controller model (which certainly could happen as we move
+        to representing the controller as a charm) then self._charm.model.name !== k8s namespace.
+        Instead, the model name is controller in Juju and controller-<controller-name> for the
+        namespace in K8s.
+
+        Returns:
+            str: A string containing the name of the current Kubernetes namespace.
+        """
+        with open("/var/run/secrets/kubernetes.io/serviceaccount/namespace", "r") as f:
+            return f.read().strip()

--- a/lib/charms/observability_libs/v0/kubernetes_compute_resources_patch.py
+++ b/lib/charms/observability_libs/v0/kubernetes_compute_resources_patch.py
@@ -93,12 +93,17 @@ def setUp(self, *unused):
     self.harness = Harness(SomeCharm)
     # ...
 ```
+
+References:
+- https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+- https://gtsystem.github.io/lightkube-models/1.23/models/core_v1/#resourcerequirements
 """
+
 import decimal
 import logging
 from decimal import Decimal
 from math import ceil, floor
-from typing import Callable, Dict, List, Optional, TypedDict, Union
+from typing import Callable, Dict, List, Optional, Union
 
 from lightkube import ApiError, Client
 from lightkube.core import exceptions
@@ -129,145 +134,88 @@ LIBAPI = 0
 LIBPATCH = 1
 
 
-class ResourceSpecDict(TypedDict, total=False):
-    """A dict representing a K8s resource limit.
-
-    See:
-    - https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-    - https://gtsystem.github.io/lightkube-models/1.23/models/core_v1/#resourcerequirements
-    """
-
-    cpu: Optional[str]
-    memory: Optional[str]
-
-
 _Decimal = Union[Decimal, float, str, int]  # types that are potentially convertible to Decimal
 
 
-def ray_hopper(x: _Decimal, a1: _Decimal, a2: _Decimal, x0: _Decimal) -> Decimal:
-    """A monotone ray hopper.
-
-    For example, this could model the thrust of a hypothetical multi-stage rocket engine, as a
-    function of time.
-
-    Args:
-        x: the value for which to calculate the function.
-        a1: the slope of the first ray.
-        a2: the slope of the second ray; must be a1 > a2.
-        x0: the crossover point from the first ray (a1) to the second ray (a2); must be x0 > 0.
-
-    Returns:
-        A linear piecewise-continuous function of x given two "rays", y = a1*x and y = a2*x,
-        and a crossover point x0, as follows:
-        - x, if 0 <= x <= x0;
-        - a1*x, if x0 < x <= a1/a2*x0;
-        - a2*x, if a1/a2*x0 < x.
-
-    >>> ray_hopper(1000, 1, "0.8", 200)  # take 0.8 * 1000
-    Decimal('800.0')
-    >>> ray_hopper(260, 1, "0.8", 200)  # take 0.8 * 260 (input value still > default / 0.8)
-    Decimal('208.0')
-    >>> ray_hopper(250, 1, "0.8", 200)  # take the default, 200 (input value <= default / 0.8)
-    Decimal('200')
-    >>> ray_hopper(200, 1, "0.8", 200)
-    Decimal('200')
-    >>> ray_hopper(150, 1, "0.8", 200)  # return the input value (input value < default)
-    Decimal('150')
-    """
-    try:
-        a1 = Decimal(a1)
-        a2 = Decimal(a2)
-        x = Decimal(x)
-        x0 = Decimal(x0)
-    except ArithmeticError:
-        raise ValueError("Invalid argument(s): all args must be (convertible to) decimal.")
-
-    if any(arg < 0 for arg in [x, a1, a2, x0]):
-        raise ValueError("Invalid argument(s): all args must be greater than 0.")
-    if a1 <= a2:
-        raise ValueError("Invalid argument: must satisfy a1 > a2.")
-
-    if x <= x0:
-        return a1 * x
-
-    a1x0 = a1 * x0
-    if x <= a1x0 / a2:
-        return a1x0
-
-    return a2 * x
-
-
-def limits_to_requests_scaled(
-    resource_limits: ResourceSpecDict, default_requests: ResourceSpecDict, scaling_factor: _Decimal
-) -> ResourceSpecDict:
-    """A helper function for calculating "requests" from a "limits" dict using a scaling factor.
-
-    With this function:
-    - When the "limits" portion is high enough, the "requests" portion is scaled down
-      proportionally, leaving some room for bursts.
-    - When the "limits" portion is too low, no scaling takes place and the requests equals the
-      limits.
+def adjust_resource_requirements(
+    limits: Optional[dict], requests: Optional[dict], adhere_to_requests: bool = True
+) -> ResourceRequirements:
+    """Adjust resource limits so that `limits` and `requests` are consistent with each other.
 
     Args:
-        resource_limits: A dictionary representation of K8s resource limits
-        default_requests: The default requests values to use if a limits value is not given. This
-            would also be used as the crossover point from requests = limits to the scaled limits.
-            For example, we can set the "requests" portion of the resource limits to a sensible
-            value, while keeping the "limits" portion unspecified.
-        scaling_factor: A scaling factor used to calculate the requests value from the limits
-            value. The scaling factor must satisfy: 0 < scaling_factor < 1.
-
-    Raises:
-        ValueError, if arguments are invalid or out of range.
+        limits: the "limits" portion of the resource spec.
+        requests: the "requests" portion of the resource spec.
+        adhere_to_requests: a flag indicating which portion should be adjusted when "limits" is
+         lower than "requests":
+         - if True, "limits" will be adjusted to max(limits, requests).
+         - if False, "requests" will be adjusted to min(limits, requests).
 
     Returns:
-        A resource spec dictionary scaled-down by scaling_factor, subject to the "default value"
-         constraint as described above.
+        An adjusted (limits, requests) 2-tuple.
 
-    >>> sf = Decimal("0.8")
-    >>> limits_to_requests_scaled({"cpu": "1"}, {"cpu": "200m"}, sf)
-    {'cpu': '0.800'}
-    >>> limits_to_requests_scaled({"cpu": "260m"}, {"cpu": "200m"}, sf)
-    {'cpu': '0.208'}
-    >>> limits_to_requests_scaled({"cpu": "250m"}, {"cpu": "200m"}, sf)
-    {'cpu': '0.200'}
-    >>> limits_to_requests_scaled({"cpu": "200m"}, {"cpu": "200m"}, sf)
-    {'cpu': '0.200'}
-    >>> limits_to_requests_scaled({"cpu": "150m"}, {"cpu": "200m"}, sf)
-    {'cpu': '0.150'}
+    >>> adjust_resource_requirements({}, {})
+    ResourceRequirements(limits={}, requests={})
+    >>> adjust_resource_requirements({"cpu": "1"}, {})
+    ResourceRequirements(limits={'cpu': '1'}, requests={})
+    >>> adjust_resource_requirements({"cpu": "1"}, {"cpu": "2"}, True)
+    ResourceRequirements(limits={'cpu': '2'}, requests={'cpu': '2'})
+    >>> adjust_resource_requirements({"cpu": "1"}, {"cpu": "2"}, False)
+    ResourceRequirements(limits={'cpu': '1'}, requests={'cpu': '1'})
+    >>> adjust_resource_requirements({"cpu": "1"}, {"memory": "1G"}, True)
+    ResourceRequirements(limits={'cpu': '1'}, requests={'memory': '1G'})
+    >>> adjust_resource_requirements({"cpu": "1"}, {"memory": "1G"}, False)
+    ResourceRequirements(limits={'cpu': '1'}, requests={'memory': '1G'})
+    >>> adjust_resource_requirements({"cpu": "1", "memory": "500M"}, {"memory": "1G"}, True)
+    ResourceRequirements(limits={'cpu': '1', 'memory': '1000000000'}, requests={'memory': '1G'})
+    >>> adjust_resource_requirements({"cpu": "1", "memory": "500M"}, {"memory": "1G"}, False)
+    ResourceRequirements(limits={'cpu': '1', 'memory': '500M'}, requests={'memory': '500000000'})
+    >>> adjust_resource_requirements({"custom-resource": "1"}, {"custom-resource": "2"}, False)
+    ResourceRequirements(limits={'custom-resource': '1'}, requests={'custom-resource': '1'})
     """
-    scaling_factor = Decimal(scaling_factor)
-    if not (0 < scaling_factor < 1):
-        raise ValueError("scaling_factor must be in the range (0, 1).")
+    if not is_valid_spec(limits):
+        raise ValueError("Invalid limits spec: {}".format(limits))
+    if not is_valid_spec(requests):
+        raise ValueError("Invalid default requests spec: {}".format(requests))
 
-    if not is_valid_spec(resource_limits):
-        raise ValueError("Invalid limits spec: {}".format(resource_limits))
-    if not is_valid_spec(default_requests):
-        raise ValueError("Invalid default requests spec: {}".format(default_requests))
+    limits = sanitize_resource_spec_dict(limits) or {}
+    requests = sanitize_resource_spec_dict(requests) or {}
 
-    resource_limits = sanitize_resource_spec_dict(resource_limits) or {}
-    default_requests = sanitize_resource_spec_dict(default_requests) or {}
+    if adhere_to_requests:
+        # Keep limits fixed when `limits` is too low
+        adjusted, fixed = limits.copy(), requests.copy()
+        func = max
+    else:
+        # Pull down requests when limit is too low
+        fixed, adjusted = limits.copy(), requests.copy()
+        func = min
 
-    # Construct a "requests" dict from a "limits" dict (user input).
-    # Default "requests" values will be used for any missing key in "limits".
-    requests = {}
-    for k in ResourceSpecDict.__annotations__.keys():
-        if k in default_requests:
-            default = parse_quantity(default_requests[k])  # type: ignore[literal-required]
-            value = (
-                ray_hopper(
-                    parse_quantity(resource_limits[k]), Decimal("1.0"), scaling_factor, default  # type: ignore[literal-required, arg-type]
-                )
-                if k in resource_limits
-                else default
-            )
-            requests[k] = str(value.quantize(decimal.Decimal("0.001"), rounding=decimal.ROUND_UP))  # type: ignore[union-attr]
+    # adjusted = {}
+    for k in adjusted:
+        if k not in fixed:
+            # The resource constraint is present in the "adjusted" dict but not in the "fixed"
+            # dict. Keep the "adjusted" value as is
+            continue
 
-    return ResourceSpecDict(requests)  # type: ignore[misc]
+        adjusted_value = func(parse_quantity(fixed[k]), parse_quantity(adjusted[k]))  # type: ignore[type-var]
+        adjusted[k] = (
+            str(adjusted_value.quantize(decimal.Decimal("0.001"), rounding=decimal.ROUND_UP))  # type: ignore[union-attr]
+            .rstrip("0")
+            .rstrip(".")
+        )
+
+    return (
+        ResourceRequirements(limits=adjusted, requests=fixed)
+        if adhere_to_requests
+        else ResourceRequirements(limits=fixed, requests=adjusted)
+    )
 
 
-def is_valid_spec(spec: Optional[ResourceSpecDict], debug=False) -> bool:  # noqa: C901
-    """Check if the spec dict is valid."""
+def is_valid_spec(spec: Optional[dict], debug=False) -> bool:  # noqa: C901
+    """Check if the spec dict is valid.
+
+    TODO: generally, the keys can be anything, not just cpu and memory. Perhaps user could pass
+     list of custom allowed keys in addition to the K8s ones?
+    """
     if spec is None:
         return True
     if not isinstance(spec, dict):
@@ -276,10 +224,6 @@ def is_valid_spec(spec: Optional[ResourceSpecDict], debug=False) -> bool:  # noq
         return False
 
     for k, v in spec.items():
-        if k not in ResourceSpecDict.__annotations__.keys():
-            if debug:
-                logger.error("Invalid resource spec entry: {%s: %s}.", k, v)
-            return False
         try:
             assert isinstance(v, (str, type(None)))  # for type checker
             pv = parse_quantity(v)
@@ -296,7 +240,7 @@ def is_valid_spec(spec: Optional[ResourceSpecDict], debug=False) -> bool:  # noq
     return True
 
 
-def sanitize_resource_spec_dict(spec: Optional[ResourceSpecDict]) -> Optional[ResourceSpecDict]:
+def sanitize_resource_spec_dict(spec: Optional[dict]) -> Optional[dict]:
     """Fix spec values without altering semantics.
 
     The purpose of this helper function is to correct known issues.
@@ -314,7 +258,7 @@ def sanitize_resource_spec_dict(spec: Optional[ResourceSpecDict]) -> Optional[Re
             # setpoint, the pod will not be scheduled and the charm would be stuck in unknown/lost.
             # This slightly changes the spec semantics compared to lightkube/k8s: a setpoint of
             # `None` would be interpreted here as "no limit".
-            del d[k]  # type: ignore
+            del d[k]
 
     # Round up memory to whole bytes. This is need to avoid K8s errors such as:
     # fractional byte value "858993459200m" (0.8Gi) is invalid, must be an integer
@@ -459,8 +403,7 @@ class KubernetesComputeResourcesPatch(Object):
         charm: CharmBase,
         container_name: str,
         *,
-        limits_func: Callable[[], Optional[ResourceSpecDict]],
-        requests_func: Callable[[], Optional[ResourceSpecDict]],
+        resource_reqs_func: Callable[[], ResourceRequirements],
         refresh_event: Optional[Union[BoundEvent, List[BoundEvent]]] = None,
     ):
         """Constructor for KubernetesComputeResourcesPatch.
@@ -471,18 +414,15 @@ class KubernetesComputeResourcesPatch(Object):
         Args:
             charm: the charm that is instantiating the library.
             container_name: the container for which to apply the resource limits.
-            limits_func: a callable returning a dictionary for `limits` resources; if raises,
-              should only raise ValueError.
-            requests_func: a callable returning a dictionary for `requests` resources; if raises,
-              should only raise ValueError.
+            resource_reqs_func: a callable returning a `ResourceRequirements`; if raises, should
+              only raise ValueError.
             refresh_event: an optional bound event or list of bound events which
                 will be observed to re-apply the patch.
         """
         super().__init__(charm, "{}_{}".format(self.__class__.__name__, container_name))
         self._charm = charm
         self._container_name = container_name
-        self.limits_func = limits_func
-        self.requests_func = requests_func
+        self.resource_reqs_func = resource_reqs_func
         self.patcher = ResourcePatcher(self._namespace, self._app, container_name)
 
         # Ensure this patch is applied during the 'config-changed' event, which is emitted every
@@ -505,8 +445,9 @@ class KubernetesComputeResourcesPatch(Object):
     def _patch(self) -> None:
         """Patch the Kubernetes resources created by Juju to limit cpu or mem."""
         try:
-            limits = self.limits_func()
-            requests = self.requests_func()
+            resource_reqs = self.resource_reqs_func()
+            limits = resource_reqs.limits
+            requests = resource_reqs.requests
         except ValueError as e:
             msg = f"Failed obtaining resource limit spec: {e}"
             logger.error(msg)
@@ -563,8 +504,9 @@ class KubernetesComputeResourcesPatch(Object):
             bool: A boolean indicating if the service patch has been applied and is in effect.
         """
         try:
-            limits = self.limits_func()
-            requests = self.requests_func()
+            resource_reqs = self.resource_reqs_func()
+            limits = resource_reqs.limits
+            requests = resource_reqs.requests
         except ValueError as e:
             msg = f"Failed obtaining resource limit spec: {e}"
             logger.error(msg)

--- a/lib/charms/observability_libs/v0/kubernetes_compute_resources_patch.py
+++ b/lib/charms/observability_libs/v0/kubernetes_compute_resources_patch.py
@@ -10,7 +10,7 @@ When initialised, this library binds a handler to the parent charm's `config-cha
 The config-changed event is used because it is guaranteed to fire on startup, on upgrade and on
 pod churn. Additionally, resource limits may be set by charm config options, which would also be
 caught out-of-the-box by this handler. The handler applies the patch to the app's StatefulSet.
-This should ensure that the resource limits are correct throughout the charm's life.Additional
+This should ensure that the resource limits are correct throughout the charm's life. Additional
 optional user-provided events for re-applying the patch are supported but discouraged.
 
 The constructor takes a reference to the parent charm, a 'limits' and a 'requests' dictionaries
@@ -40,6 +40,7 @@ Then, to initialise the library:
 from charms.observability_libs.v0.kubernetes_compute_resources_patch import (
     KubernetesComputeResourcesPatch
 )
+from lightkube.models.core_v1 import ResourceRequirements
 
 class SomeCharm(CharmBase):
   def __init__(self, *args):
@@ -47,31 +48,32 @@ class SomeCharm(CharmBase):
     self.resources_patch = KubernetesComputeResourcesPatch(
         self,
         "container-name",
-        limits_func=lambda: {"cpu": "1", "mem": "2Gi"},
-        requests_func=lambda: {"cpu": "1", "mem": "2Gi"}
+        resource_reqs_func=lambda: ResourceRequirements(
+            limits={"cpu": "2"}, requests={"cpu": "1"}
+        ),
     )
+    self.framework.observe(self.resources_patch.on.patch_failed, self._on_resource_patch_failed)
+
+  def _on_resource_patch_failed(self, event):
+    self.unit.status = BlockedStatus(event.message)
     # ...
 ```
 
 Or, if, for example, the resource specs are coming from config options:
 
 ```python
-# ...
-
 class SomeCharm(CharmBase):
   def __init__(self, *args):
     # ...
     self.resources_patch = KubernetesComputeResourcesPatch(
         self,
         "container-name",
-        limits_func=lambda: self._resource_spec_from_config(),
-        requests_func=lambda: self._resource_spec_from_config(),
+        resource_reqs_func=lambda: self._resource_spec_from_config(),
     )
 
-  def _resource_spec_from_config(self):
-    return {"cpu": self.model.config.get("cpu"), "memory": self.model.config.get("memory")}
-
-    # ...
+  def _resource_spec_from_config(self) -> ResourceRequirements:
+    spec = {"cpu": self.model.config.get("cpu"), "memory": self.model.config.get("memory")}
+    return ResourceRequirements(limits=spec, requests=spec)
 ```
 
 
@@ -156,19 +158,19 @@ def adjust_resource_requirements(
     >>> adjust_resource_requirements({}, {})
     ResourceRequirements(limits={}, requests={})
     >>> adjust_resource_requirements({"cpu": "1"}, {})
-    ResourceRequirements(limits={'cpu': '1'}, requests={})
+    ResourceRequirements(limits={'cpu': '1'}, requests={'cpu': '1'})
     >>> adjust_resource_requirements({"cpu": "1"}, {"cpu": "2"}, True)
     ResourceRequirements(limits={'cpu': '2'}, requests={'cpu': '2'})
     >>> adjust_resource_requirements({"cpu": "1"}, {"cpu": "2"}, False)
     ResourceRequirements(limits={'cpu': '1'}, requests={'cpu': '1'})
     >>> adjust_resource_requirements({"cpu": "1"}, {"memory": "1G"}, True)
-    ResourceRequirements(limits={'cpu': '1'}, requests={'memory': '1G'})
+    ResourceRequirements(limits={'cpu': '1'}, requests={'memory': '1G', 'cpu': '1'})
     >>> adjust_resource_requirements({"cpu": "1"}, {"memory": "1G"}, False)
-    ResourceRequirements(limits={'cpu': '1'}, requests={'memory': '1G'})
-    >>> adjust_resource_requirements({"cpu": "1", "memory": "500M"}, {"memory": "1G"}, True)
-    ResourceRequirements(limits={'cpu': '1', 'memory': '1000000000'}, requests={'memory': '1G'})
-    >>> adjust_resource_requirements({"cpu": "1", "memory": "500M"}, {"memory": "1G"}, False)
-    ResourceRequirements(limits={'cpu': '1', 'memory': '500M'}, requests={'memory': '500000000'})
+    ResourceRequirements(limits={'cpu': '1'}, requests={'memory': '1G', 'cpu': '1'})
+    >>> adjust_resource_requirements({"cpu": "1", "memory": "1"}, {"memory": "2"}, True)
+    ResourceRequirements(limits={'cpu': '1', 'memory': '2'}, requests={'memory': '2', 'cpu': '1'})
+    >>> adjust_resource_requirements({"cpu": "1", "memory": "1"}, {"memory": "1G"}, False)
+    ResourceRequirements(limits={'cpu': '1', 'memory': '1'}, requests={'memory': '1', 'cpu': '1'})
     >>> adjust_resource_requirements({"custom-resource": "1"}, {"custom-resource": "2"}, False)
     ResourceRequirements(limits={'custom-resource': '1'}, requests={'custom-resource': '1'})
     """
@@ -180,13 +182,21 @@ def adjust_resource_requirements(
     limits = sanitize_resource_spec_dict(limits) or {}
     requests = sanitize_resource_spec_dict(requests) or {}
 
+    # Make sure we do not modify in-place
+    limits, requests = limits.copy(), requests.copy()
+
+    # Need to copy key-val pairs from "limits" to "requests", if they are not present in
+    # "requests". This replicates K8s behavior:
+    # https://kubernetes.io/docs/concepts/configuration/manage-resources-containers
+    requests.update({k: limits[k] for k in limits if k not in requests})
+
     if adhere_to_requests:
         # Keep limits fixed when `limits` is too low
-        adjusted, fixed = limits.copy(), requests.copy()
+        adjusted, fixed = limits, requests
         func = max
     else:
         # Pull down requests when limit is too low
-        fixed, adjusted = limits.copy(), requests.copy()
+        fixed, adjusted = limits, requests
         func = min
 
     # adjusted = {}
@@ -372,6 +382,12 @@ class ResourcePatcher:
         Returns:
             bool: A boolean indicating if the service patch has been applied and is in effect.
         """
+        logger.info(
+            "reqs=%s, templated=%s, actual=%s",
+            resource_reqs,
+            self.get_templated(),
+            self.get_actual(pod_name),
+        )
         return self.is_patched(resource_reqs) and equals_canonically(
             resource_reqs, self.get_actual(pod_name)
         )
@@ -513,6 +529,7 @@ class KubernetesComputeResourcesPatch(Object):
             return False
 
         if not is_valid_spec(limits) or not is_valid_spec(requests):
+            logger.error("Invalid resource requirements specs: %s, %s", limits, requests)
             return False
 
         resource_reqs = ResourceRequirements(

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,5 +23,5 @@ PyYAML
 # Code: https://github.com/gtsystem/lightkube
 # Docs: https://lightkube.readthedocs.io/
 # Deps: observability_libs
-lightkube
+lightkube >= 0.11
 lightkube-models

--- a/src/charm.py
+++ b/src/charm.py
@@ -15,13 +15,25 @@ from charms.alertmanager_k8s.v0.alertmanager_dispatch import AlertmanagerProvide
 from charms.grafana_k8s.v0.grafana_dashboard import GrafanaDashboardProvider
 from charms.grafana_k8s.v0.grafana_source import GrafanaSourceProvider
 from charms.karma_k8s.v0.karma_dashboard import KarmaProvider
+from charms.observability_libs.v0.kubernetes_compute_resources_patch import (
+    K8sResourcePatchFailedEvent,
+    KubernetesComputeResourcesPatch,
+    ResourceSpecDict,
+    limits_to_requests_scaled,
+)
 from charms.observability_libs.v0.kubernetes_service_patch import KubernetesServicePatch
 from charms.prometheus_k8s.v0.prometheus_scrape import MetricsEndpointProvider
 from charms.traefik_k8s.v1.ingress import IngressPerAppRequirer
 from ops.charm import ActionEvent, CharmBase
 from ops.framework import StoredState
 from ops.main import main
-from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus, Relation
+from ops.model import (
+    ActiveStatus,
+    BlockedStatus,
+    MaintenanceStatus,
+    Relation,
+    WaitingStatus,
+)
 from ops.pebble import ChangeError, ExecError, Layer, PathError, ProtocolError
 
 from alertmanager_client import Alertmanager, AlertmanagerBadResponse
@@ -105,6 +117,17 @@ class AlertmanagerCharm(CharmBase):
                 (f"{self.app.name}-ha", self._ha_port, self._ha_port),
             ],
         )
+        self.resources_patch = KubernetesComputeResourcesPatch(
+            self,
+            self._container_name,
+            limits_func=lambda: self._resource_limit_from_config(),
+            requests_func=lambda: limits_to_requests_scaled(
+                self._resource_limit_from_config(),
+                ResourceSpecDict(cpu="0.25", memory="200Mi"),
+                0.8,
+            ),
+        )
+        self.framework.observe(self.resources_patch.on.patch_failed, self._on_k8s_patch_failed)
 
         # Self-monitoring
         self._scraping = MetricsEndpointProvider(
@@ -132,6 +155,16 @@ class AlertmanagerCharm(CharmBase):
         # Action events
         self.framework.observe(self.on.show_config_action, self._on_show_config_action)
         self.framework.observe(self.on.check_config_action, self._on_check_config)
+
+    def _resource_limit_from_config(self):
+        resource_limit = ResourceSpecDict(
+            cpu=self.model.config.get("cpu"),
+            memory=self.model.config.get("memory"),
+        )
+        return resource_limit
+
+    def _on_k8s_patch_failed(self, event: K8sResourcePatchFailedEvent):
+        self.unit.status = BlockedStatus(event.message)
 
     def _handle_ingress(self, event):
         if url := self.ingress.url:
@@ -437,6 +470,11 @@ class AlertmanagerCharm(CharmBase):
 
     def _common_exit_hook(self) -> None:
         """Event processing hook that is common to all events to ensure idempotency."""
+        if not self.resources_patch.is_ready():
+            if isinstance(self.unit.status, ActiveStatus) or self.unit.status.message == "":
+                self.unit.status = WaitingStatus("Waiting for resource limit patch to apply")
+            return
+
         if not self.container.can_connect():
             self.unit.status = MaintenanceStatus("Waiting for pod startup to complete")
             return

--- a/tests/integration/test_config_changed_modifies_file.py
+++ b/tests/integration/test_config_changed_modifies_file.py
@@ -33,7 +33,9 @@ async def test_build_and_deploy(ops_test: OpsTest, charm_under_test):
     Assert on the unit status before any relations/configurations take place.
     """
     # deploy charm from local source folder
-    await ops_test.model.deploy(charm_under_test, resources=resources, application_name=app_name)
+    await ops_test.model.deploy(
+        charm_under_test, resources=resources, application_name=app_name, trust=True
+    )
     await ops_test.model.wait_for_idle(apps=[app_name], status="active", timeout=1000)
     assert ops_test.model.applications[app_name].units[0].workload_status == "active"
     assert await is_alertmanager_up(ops_test, app_name)

--- a/tests/integration/test_external_url.py
+++ b/tests/integration/test_external_url.py
@@ -32,7 +32,9 @@ async def test_setup_env(ops_test: OpsTest):
 @pytest.mark.abort_on_fail
 async def test_build_and_deploy(ops_test: OpsTest, charm_under_test):
     # deploy charm from local source folder
-    await ops_test.model.deploy(charm_under_test, resources=resources, application_name=app_name)
+    await ops_test.model.deploy(
+        charm_under_test, resources=resources, application_name=app_name, trust=True
+    )
     await ops_test.model.wait_for_idle(status="active", timeout=deploy_timeout)
     assert await is_alertmanager_up(ops_test, app_name)
 

--- a/tests/integration/test_kubectl_delete.py
+++ b/tests/integration/test_kubectl_delete.py
@@ -23,7 +23,9 @@ async def test_deploy_from_local_path(ops_test: OpsTest, charm_under_test):
     """Deploy the charm-under-test."""
     logger.debug("deploy local charm")
 
-    await ops_test.model.deploy(charm_under_test, application_name=app_name, resources=resources)
+    await ops_test.model.deploy(
+        charm_under_test, application_name=app_name, resources=resources, trust=True
+    )
     await ops_test.model.wait_for_idle(apps=[app_name], status="active", timeout=1000)
     await is_alertmanager_up(ops_test, app_name)
 

--- a/tests/integration/test_persistence.py
+++ b/tests/integration/test_persistence.py
@@ -24,7 +24,9 @@ resources = {"alertmanager-image": METADATA["resources"]["alertmanager-image"]["
 async def test_silences_persist_across_upgrades(ops_test: OpsTest, charm_under_test, httpserver):
     # deploy alertmanager charm from charmhub
     logger.info("deploy charm from charmhub")
-    await ops_test.model.deploy("ch:alertmanager-k8s", application_name=app_name, channel="edge")
+    await ops_test.model.deploy(
+        "ch:alertmanager-k8s", application_name=app_name, channel="edge", trust=True
+    )
     await ops_test.model.wait_for_idle(apps=[app_name], status="active", timeout=1000)
 
     # set a silencer for an alert and check it is set

--- a/tests/integration/test_rerelate_alertmanager_dispatch_metrics_endpoint.py
+++ b/tests/integration/test_rerelate_alertmanager_dispatch_metrics_endpoint.py
@@ -34,7 +34,11 @@ async def test_build_and_deploy(ops_test: OpsTest, charm_under_test):
     """Build the charm-under-test and deploy it together with related charms."""
     await asyncio.gather(
         ops_test.model.deploy(
-            charm_under_test, resources=resources, application_name=app_name, num_units=2
+            charm_under_test,
+            resources=resources,
+            application_name=app_name,
+            num_units=2,
+            trust=True,
         ),
         ops_test.model.deploy(
             "ch:prometheus-k8s", application_name=related_app, channel="edge", trust=True

--- a/tests/integration/test_rescale_charm.py
+++ b/tests/integration/test_rescale_charm.py
@@ -34,7 +34,7 @@ async def test_deploy_multiple_units(ops_test: OpsTest, charm_under_test):
 
     logger.info("deploy charm")
     await ops_test.model.deploy(
-        charm_under_test, application_name=app_name, resources=resources, num_units=10
+        charm_under_test, application_name=app_name, resources=resources, num_units=10, trust=True
     )
     await block_until_leader_elected(ops_test, app_name)
 

--- a/tests/integration/test_templates.py
+++ b/tests/integration/test_templates.py
@@ -31,7 +31,9 @@ template = r'{{ define "slack.default.callbackid" }}' + callback_id + "{{ end }}
 @pytest.mark.abort_on_fail
 async def test_build_and_deploy(ops_test: OpsTest, charm_under_test):
     # deploy charm from local source folder
-    await ops_test.model.deploy(charm_under_test, resources=resources, application_name=app_name)
+    await ops_test.model.deploy(
+        charm_under_test, resources=resources, application_name=app_name, trust=True
+    )
     await ops_test.model.wait_for_idle(apps=[app_name], status="active", timeout=1000)
     assert ops_test.model.applications[app_name].units[0].workload_status == "active"
     assert await is_alertmanager_up(ops_test, app_name)

--- a/tests/integration/test_update_status_pressure.py
+++ b/tests/integration/test_update_status_pressure.py
@@ -40,7 +40,11 @@ async def test_deploy_multiple_units(ops_test: OpsTest, charm_under_test):
     logger.info("deploy charms")
     await asyncio.gather(
         ops_test.model.deploy(
-            charm_under_test, application_name=app_name, resources=resources, num_units=2
+            charm_under_test,
+            application_name=app_name,
+            resources=resources,
+            num_units=2,
+            trust=True,
         ),
         ops_test.model.deploy(
             "ch:prometheus-k8s", application_name="prom", channel="edge", trust=True

--- a/tests/integration/test_upgrade_charm.py
+++ b/tests/integration/test_upgrade_charm.py
@@ -38,7 +38,9 @@ async def test_setup_env(ops_test: OpsTest):
 async def test_upgrade_edge_with_local_in_isolation(ops_test: OpsTest, charm_under_test):
     """Build the charm-under-test, deploy the charm from charmhub, and upgrade from path."""
     logger.info("deploy charm from charmhub")
-    await ops_test.model.deploy("ch:alertmanager-k8s", application_name=app_name, channel="edge")
+    await ops_test.model.deploy(
+        "ch:alertmanager-k8s", application_name=app_name, channel="edge", trust=True
+    )
     await ops_test.model.wait_for_idle(apps=[app_name], status="active", timeout=1000)
 
     logger.info("upgrade deployed charm with local charm %s", charm_under_test)

--- a/tests/unit/helpers.py
+++ b/tests/unit/helpers.py
@@ -4,12 +4,14 @@
 
 """Helper functions for writing tests."""
 
+from unittest.mock import patch
 
-def no_op(*args, **kwargs) -> None:
+
+def no_op(*_, **__) -> None:
     pass
 
 
-def tautology(*args, **kwargs) -> bool:
+def tautology(*_, **__) -> bool:
     return True
 
 
@@ -23,3 +25,11 @@ def cli_arg(plan, cli_opt):
         if len(opt_list) == 1 and opt_list[0] == cli_opt:
             return opt_list[0]
     return None
+
+
+k8s_resource_multipatch = patch.multiple(
+    "charm.KubernetesComputeResourcesPatch",
+    _namespace="test-namespace",
+    _patch=tautology,
+    is_ready=tautology,
+)

--- a/tests/unit/test_external_url.py
+++ b/tests/unit/test_external_url.py
@@ -8,7 +8,7 @@ from unittest.mock import patch
 
 import ops
 import yaml
-from helpers import cli_arg, tautology
+from helpers import cli_arg, k8s_resource_multipatch, tautology
 from ops.model import ActiveStatus, BlockedStatus
 from ops.testing import Harness
 
@@ -26,6 +26,8 @@ class TestExternalUrl(unittest.TestCase):
     @patch.object(AlertmanagerCharm, "_check_config", lambda *a, **kw: ("ok", ""))
     @patch("charm.KubernetesServicePatch", lambda x, y: None)
     @patch("socket.getfqdn", new=lambda *args: "fqdn")
+    @k8s_resource_multipatch
+    @patch("lightkube.core.client.GenericSyncClient")
     def setUp(self, *unused):
         self.harness = Harness(AlertmanagerCharm)
         self.harness.set_model_name(self.__class__.__name__)
@@ -62,6 +64,7 @@ class TestExternalUrl(unittest.TestCase):
 
     @patch.object(AlertmanagerCharm, "_check_config", lambda *a, **kw: ("ok", ""))
     @patch("socket.getfqdn", new=lambda *args: "fqdn")
+    @k8s_resource_multipatch
     def test_config_option_overrides_fqdn(self):
         """The config option for external url must override all other external urls."""
         # GIVEN a charm with the fqdn as its external URL
@@ -85,6 +88,7 @@ class TestExternalUrl(unittest.TestCase):
 
     @patch.object(AlertmanagerCharm, "_check_config", lambda *a, **kw: ("ok", ""))
     @patch("socket.getfqdn", new=lambda *args: "fqdn")
+    @k8s_resource_multipatch
     def test_config_option_overrides_traefik(self):
         """The config option for external url must override all other external urls."""
         # GIVEN a charm with the fqdn as its external URL
@@ -125,6 +129,7 @@ class TestExternalUrl(unittest.TestCase):
 
     @patch.object(AlertmanagerCharm, "_check_config", lambda *a, **kw: ("ok", ""))
     @patch("socket.getfqdn", new=lambda *args: "fqdn")
+    @k8s_resource_multipatch
     def test_web_route_prefix(self):
         # GIVEN a charm with an external web route prefix
         external_url = "http://foo.bar:8080/path/to/alertmanager/"
@@ -158,7 +163,8 @@ class TestExternalUrl(unittest.TestCase):
 
     @patch.object(AlertmanagerCharm, "_check_config", lambda *a, **kw: ("ok", ""))
     @patch("socket.getfqdn", new=lambda *args: "fqdn-0")
-    def test_cluster_addresses(self):
+    @k8s_resource_multipatch
+    def test_cluster_addresses(self, *_):
         # GIVEN an alertmanager charm with 3 units in total
         for u in [1, 2]:
             unit_name = self.app_name + f"/{u}"
@@ -198,6 +204,7 @@ class TestExternalUrl(unittest.TestCase):
 
     @patch.object(AlertmanagerCharm, "_check_config", lambda *a, **kw: ("ok", ""))
     @patch("socket.getfqdn", new=lambda *args: "fqdn")
+    @k8s_resource_multipatch
     def test_invalid_web_route_prefix(self):
         for invalid_url in ["htp://foo.bar", "foo.bar"]:
             with self.subTest(url=invalid_url):

--- a/tests/unit/test_push_config_to_workload_on_startup.py
+++ b/tests/unit/test_push_config_to_workload_on_startup.py
@@ -10,7 +10,7 @@ import hypothesis.strategies as st
 import ops
 import validators
 import yaml
-from helpers import tautology
+from helpers import k8s_resource_multipatch, tautology
 from hypothesis import given
 from ops.model import ActiveStatus, BlockedStatus
 from ops.testing import Harness
@@ -31,6 +31,8 @@ class TestPushConfigToWorkloadOnStartup(unittest.TestCase):
     @patch.object(Alertmanager, "reload", tautology)
     @patch.object(AlertmanagerCharm, "_check_config", lambda *a, **kw: ("ok", ""))
     @patch("charm.KubernetesServicePatch", lambda *a, **kw: None)
+    @k8s_resource_multipatch
+    @patch("lightkube.core.client.GenericSyncClient")
     def setUp(self, *_):
         self.harness = Harness(AlertmanagerCharm)
         self.addCleanup(self.harness.cleanup)
@@ -72,38 +74,30 @@ class TestPushConfigToWorkloadOnStartup(unittest.TestCase):
         # AND peer clusters cli arg is not present in pebble layer command
         self.assertNotIn("--cluster.peer=", command)
 
-    @given(st.booleans(), st.integers(2, 10))
-    def test_multi_unit_cluster(self, is_leader, num_units):
+    @k8s_resource_multipatch
+    def test_multi_unit_cluster(self, *_):
         """Scenario: Current unit is a part of a multi-unit cluster."""
-        # without the try-finally, if any assertion fails, then hypothesis would reenter without
-        # the cleanup, carrying forward the units that were previously added
-        try:
-            self.assertEqual(self.harness.model.app.planned_units(), 1)
+        self.harness.set_leader(False)
 
-            # WHEN multiple units are present
-            for i in range(1, num_units):
-                self.harness.add_relation_unit(self.peer_rel_id, f"{self.app_name}/{i}")
-                self.harness.update_relation_data(
-                    self.peer_rel_id,
-                    f"{self.app_name}/{i}",
-                    {"private_address": f"http://fqdn-{i}"},
-                )
-
-            self.assertEqual(self.harness.model.app.planned_units(), num_units)
-            self.harness.set_leader(is_leader)
-
-            # THEN peer clusters cli arg is present in pebble layer command
-            command = (
-                self.harness.get_container_pebble_plan(self.harness.charm._container_name)
-                .services[self.harness.charm._service_name]
-                .command
+        # WHEN multiple units are present
+        num_units = 3
+        for i in range(1, num_units):
+            self.harness.add_relation_unit(self.peer_rel_id, f"{self.app_name}/{i}")
+            self.harness.update_relation_data(
+                self.peer_rel_id,
+                f"{self.app_name}/{i}",
+                {"private_address": f"http://fqdn-{i}"},
             )
-            self.assertIn("--cluster.peer=", command)
 
-        finally:
-            # cleanup added units to prep for reentry by hypothesis' strategy
-            for i in reversed(range(1, num_units)):
-                self.harness.remove_relation_unit(self.peer_rel_id, f"{self.app_name}/{i}")
+        self.assertEqual(self.harness.model.app.planned_units(), num_units)
+
+        # THEN peer clusters cli arg is present in pebble layer command
+        command = (
+            self.harness.get_container_pebble_plan(self.harness.charm._container_name)
+            .services[self.harness.charm._service_name]
+            .command
+        )
+        self.assertIn("--cluster.peer=", command)
 
     def test_charm_blocks_on_connection_error(self):
         self.assertIsInstance(self.harness.charm.unit.status, ActiveStatus)
@@ -119,14 +113,16 @@ class TestInvalidConfig(unittest.TestCase):
     otherwise pebble will keep trying to restart it, resulting in an idle crash-loop.
     """
 
-    def setUp(self, *_):
+    def setUp(self):
         self.harness = Harness(AlertmanagerCharm)
         self.addCleanup(self.harness.cleanup)
 
     @patch.object(Alertmanager, "reload", tautology)
     @patch.object(AlertmanagerCharm, "_check_config", lambda *a, **kw: ("", "some error"))
     @patch("charm.KubernetesServicePatch", lambda *a, **kw: None)
-    def test_charm_blocks_on_invalid_config_on_startup(self):
+    @k8s_resource_multipatch
+    @patch("lightkube.core.client.GenericSyncClient")
+    def test_charm_blocks_on_invalid_config_on_startup(self, *_):
         # GIVEN an invalid config file (mocked above)
         # WHEN the charm starts
         self.harness.begin_with_initial_hooks()
@@ -137,7 +133,9 @@ class TestInvalidConfig(unittest.TestCase):
 
     @patch.object(Alertmanager, "reload", tautology)
     @patch("charm.KubernetesServicePatch", lambda *a, **kw: None)
-    def test_charm_blocks_on_invalid_config_changed(self):
+    @k8s_resource_multipatch
+    @patch("lightkube.core.client.GenericSyncClient")
+    def test_charm_blocks_on_invalid_config_changed(self, *_):
         # GIVEN a valid configuration (mocked below)
         with patch.object(AlertmanagerCharm, "_check_config", lambda *a, **kw: ("ok", "")):
             # WHEN the charm starts

--- a/tox.ini
+++ b/tox.ini
@@ -41,7 +41,7 @@ commands =
 description = Check code against coding style standards
 deps =
     black
-    flake8 < 5.0.0
+    flake8 < 5
     flake8-docstrings
     flake8-copyright
     flake8-builtins
@@ -105,8 +105,8 @@ commands =
 [testenv:integration]
 description = Run integration tests
 deps =
-    #git+https://github.com/juju/python-libjuju.git
-    juju
+    git+https://github.com/juju/python-libjuju.git
+    #juju
     pytest
     #git+https://github.com/charmed-kubernetes/pytest-operator.git
     pytest-operator

--- a/tox.ini
+++ b/tox.ini
@@ -41,7 +41,7 @@ commands =
 description = Check code against coding style standards
 deps =
     black
-    flake8
+    flake8 < 5.0.0
     flake8-docstrings
     flake8-copyright
     flake8-builtins


### PR DESCRIPTION
## Issue
Need to be able to limit resource usage of a charm.


## Solution
- Use lib to patch k8s compute resource `limits` and `requests`.
- Automatically deduce "requests" from "limit"


## Context
[observability-libs/19](https://github.com/canonical/observability-libs/pull/19).


## Testing Instructions
- Deploy charm and look at `kubectl describe statefulset -n welcome alertmanager-k8s`.
- itests.


## Release Notes
Use compute resource patch to limit resources.
