### PR TITLE
Fixing compatibility with Python3.5

### DIFF
--- a/lib/charms/alertmanager_k8s/v0/alertmanager_remote_configuration.py
+++ b/lib/charms/alertmanager_k8s/v0/alertmanager_remote_configuration.py
@@ -24,7 +24,6 @@ the `RemoteConfigurationRequirer`.
 
 import json
 import logging
-from pathlib import Path
 from typing import Optional, Tuple
 
 import yaml
@@ -49,7 +48,7 @@ DEFAULT_RELATION_NAME = "remote-configuration"
 class ConfigReadError(Exception):
     """Raised if Alertmanager configuration can't be read."""
 
-    def __init__(self, config_file: Path):
+    def __init__(self, config_file: str):
         self.message = "Failed to read {}".format(config_file)
 
         super().__init__(self.message)
@@ -343,7 +342,7 @@ class RemoteConfigurationProvider(Object):
     def with_config_file(
         cls,
         charm: CharmBase,
-        config_file: Path,
+        config_file: str,
         relation_name: str = DEFAULT_RELATION_NAME,
     ):
         """The RemoteConfigurationProvider object factory.
@@ -373,7 +372,7 @@ class RemoteConfigurationProvider(Object):
         self.update_relation_data_bag(self.alertmanager_config)
 
     @staticmethod
-    def load_config_file(path: Path) -> dict:
+    def load_config_file(path: str) -> dict:
         """Reads given Alertmanager configuration file and turns it into a dictionary.
 
         Args:
@@ -435,7 +434,7 @@ class RemoteConfigurationProvider(Object):
         return templates
 
     @staticmethod
-    def _load_templates_file(path: Path) -> str:
+    def _load_templates_file(path: str) -> str:
         """Reads given Alertmanager templates file and returns its content in a form of a string.
 
         Args:

--- a/tests/integration/remote_configuration_tester/src/charm.py
+++ b/tests/integration/remote_configuration_tester/src/charm.py
@@ -5,7 +5,6 @@
 """A Charm to functionally test the Alertmanager Operator."""
 
 import logging
-from pathlib import Path
 
 from charms.alertmanager_k8s.v0.alertmanager_remote_configuration import (
     ConfigReadError,
@@ -21,7 +20,7 @@ logger = logging.getLogger(__name__)
 class AlertmanagerTesterCharm(CharmBase):
     """A Charm to functionally test the Alertmanager Operator."""
 
-    ALERTMANAGER_CONFIG_FILE = Path("/etc/alertmanager/alertmanager.yml")
+    ALERTMANAGER_CONFIG_FILE = "/etc/alertmanager/alertmanager.yml"
 
     def __init__(self, *args):
         super().__init__(*args)

--- a/tests/unit/test_remote_configuration_provider.py
+++ b/tests/unit/test_remote_configuration_provider.py
@@ -4,7 +4,6 @@
 import json
 import logging
 import unittest
-from pathlib import Path
 from unittest.mock import PropertyMock, patch
 
 import yaml
@@ -53,7 +52,7 @@ class RemoteConfigurationProviderCharm(CharmBase):
         super().__init__(*args)
 
         alertmanager_config = RemoteConfigurationProvider.load_config_file(
-            Path(self.ALERTMANAGER_CONFIG_FILE)
+            self.ALERTMANAGER_CONFIG_FILE
         )
         self.remote_configuration_provider = RemoteConfigurationProvider(
             charm=self,
@@ -66,7 +65,7 @@ class RemoteConfigurationProviderCharm(CharmBase):
     def _update_config(self, _):
         try:
             alertmanager_config = RemoteConfigurationProvider.load_config_file(
-                Path(self.ALERTMANAGER_CONFIG_FILE)
+                self.ALERTMANAGER_CONFIG_FILE
             )
             self.remote_configuration_provider.update_relation_data_bag(alertmanager_config)
         except ConfigReadError:


### PR DESCRIPTION
Fixing `open()` compatibility problem.

Since the CI is not picking up the changes from the PR, here's a proof that the static analysis actually passes:
```shell
root@ip-172-31-15-218:~/alertmanager-k8s-operator# python3 --version
Python 3.5.10
root@ip-172-31-15-218:~/alertmanager-k8s-operator# tox -e static-lib
static-lib installed: DEPRECATION: Python 3.5 reached the end of its life on September 13th, 2020. Please upgrade your Python as Python 3.5 is no longer maintained. pip 21.0 will drop support for Python 3.5 in January 2021. pip 21.0 will remove support for this functionality.,mypy==0.910,mypy-extensions==0.4.3,ops @ git+https://github.com/canonical/operator@5bc3acb40fc0db4887b2377fd0ed7a9591df78e9,PyYAML==5.3.1,toml==0.10.2,typed-ast==1.4.3,types-PyYAML==6.0.11,types-requests==2.28.10,types-setuptools==65.3.0,types-toml==0.10.8,types-urllib3==1.26.24,typing-extensions==3.10.0.2
static-lib run-test-pre: PYTHONHASHSEED='2407777773'
static-lib run-test: commands[0] | mypy --python-version 3.5 /root/alertmanager-k8s-operator/lib/charms/alertmanager_k8s
Success: no issues found in 2 source files
_____________________________________________________________________________________________________ summary _____________________________________________________________________________________________________
  static-lib: commands succeeded
  congratulations :)
```