### PR TITLE
Rename self-monitoring dashboard

### DIFF
--- a/src/grafana_dashboards/alertmanager_rev4.json.tmpl
+++ b/src/grafana_dashboards/alertmanager_rev4.json.tmpl
@@ -11156,7 +11156,7 @@
     ]
   },
   "timezone": "",
-  "title": "Alertmanager",
+  "title": "Alertmanager Operator Overview",
   "uid": "eea-9_sik",
   "version": 27
 }


### PR DESCRIPTION
The Alertmanager dashboard is currently simply named `Alertmanager`. To have it match the name of our other operator dashboards, this PR renames it to `Alertmanager Operator Overview`.