### PR TITLE
Fix RemoteConfigurationRequirer tests on ops 2.0.0

### DIFF
--- a/tests/unit/test_remote_configuration_requirer.py
+++ b/tests/unit/test_remote_configuration_requirer.py
@@ -49,8 +49,18 @@ class TestAlertmanagerRemoteConfigurationRequirer(unittest.TestCase):
         self.harness = testing.Harness(AlertmanagerCharm)
         self.addCleanup(self.harness.cleanup)
         self.harness.set_leader(True)
+
+        # TODO: Once we're on ops 2.0.0+ this can be removed as begin_with_initial_hooks()
+        # now does it.
         self.harness.set_can_connect("alertmanager", True)
-        self.harness.begin_with_initial_hooks()
+
+        with patch("ops.model.Container.exec") as patched_exec:
+            # In ops 2.0.0+, we need to mock exec, as begin_with_initial_hooks() now triggers
+            # pebble-ready, which execs "alertmanager --version".
+            patched_exec_mock = Mock()
+            patched_exec_mock.wait_output.return_value = ("alertmanager, version 0.23.0", "")
+            patched_exec.return_value = patched_exec_mock
+            self.harness.begin_with_initial_hooks()
 
         self.relation_id = self.harness.add_relation(
             DEFAULT_RELATION_NAME, "remote-config-provider"


### PR DESCRIPTION
Currently the TestAlertmanagerRemoteConfigurationRequirer unit tests fail on ops ops==2.0.0rc2 because begin_with_initial_hooks() has been changed to trigger pebble-ready.

You can try this by replacing "ops" in requirements.txt with "ops==2.0.0rc2" and running "tox -e unit", or just the specific tests:

```
tox -e unit -- -k TestAlertmanagerRemoteConfigurationRequirer
```

Once the Charm Tech team releases ops 2.0.0 final we can update requirements.txt to use it, and remove the TODO comment and set_can_connect() call.