### PR TITLE
check version bump on library modifications

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -75,8 +75,13 @@ deps =
 commands =
     charm: mypy {[vars]src_path} {posargs}
     lib: mypy --python-version 3.5 {[vars]lib_path} {posargs}
+    lib: /usr/bin/env sh -c 'for m in $(git diff main --name-only {[vars]lib_path}); do \
+    lib:    if ! git diff $m | grep -q "+LIBPATCH\|+LIBAPI"; then \
+    lib:        echo "You forgot to bump the version on $m!"; exit 1; \
+    lib:    fi; done'
     unit: mypy {[vars]tst_path}/unit {posargs}
     integration: mypy {[vars]tst_path}/integration {posargs}
+allowlist_externals = /usr/bin/env
 
 [testenv:reqs]
 description = Check for missing or unused requirements


### PR DESCRIPTION
## Issue
Forgetting to bump LIBPATCH on a library update causes that update to not be detected at any level, as the CI won't release a new library, but it can be detected by the PR label, leading to confusion.


## Solution
Add a simple check to the `static-lib` tox environment to make sure that *if* a library has been modified, its LIBPATCH has been bumped. Once this is approved and merged, I will replicate it to all of our other repos.   
I'm open to have this somewhere else if you think it's better, such as its own tox environment (which would require modfiying the *_quality_checks* CI to also run that step), or anywhere else.

## Context
Note that this is intentionally a loose check (it only checks if the LIBPATCH line was modified); this allows for *some* flexibility in not bumping the version by just adding a comment to that line.  
However, if there's a need for multiple PRs on the same library, and we don't want to release the library every time, the correct approach is probably to create another branch out of main (i.e., `library-change`); then merge the different PRs to `library-change`, and finally open a PR from that branch to main.
