### PR TITLE
Use Juju 3.1 for CI

### DIFF
--- a/lib/charms/observability_libs/v0/juju_topology.py
+++ b/lib/charms/observability_libs/v0/juju_topology.py
@@ -75,7 +75,7 @@ from uuid import UUID
 LIBID = "bced1658f20f49d28b88f61f83c2d232"
 
 LIBAPI = 0
-LIBPATCH = 4
+LIBPATCH = 6
 
 
 class InvalidUUIDError(Exception):
@@ -87,7 +87,11 @@ class InvalidUUIDError(Exception):
 
 
 class JujuTopology:
-    """JujuTopology is used for storing, generating and formatting juju topology information."""
+    """JujuTopology is used for storing, generating and formatting juju topology information.
+
+    DEPRECATED: This class is deprecated. Use `pip install cosl` and
+    `from cosl.juju_topology import JujuTopology` instead.
+    """
 
     def __init__(
         self,

--- a/tox.ini
+++ b/tox.ini
@@ -110,7 +110,7 @@ commands =
 description = Run integration tests
 deps =
     deepdiff
-    juju ~= 3.0.0
+    juju
     pytest
     pytest-operator
     pytest-httpserver

--- a/tox.ini
+++ b/tox.ini
@@ -123,7 +123,7 @@ bundle_dir = {envtmpdir}/cos-lite-bundle
 deps =
     # deps from cos-lite bundle - these are needed here because running pytest on the bundle
     jinja2
-    juju ~= 3.0.0
+    juju
     pytest
     pytest-operator
 allowlist_externals =


### PR DESCRIPTION
Use Juju 3.1 to get around the unit termination issue. Update libs.

