### PR TITLE
Switch Alertmanager to use the ROCK on ghcr.io

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -34,7 +34,7 @@ resources:
   alertmanager-image:
     type: oci-image
     description: OCI image for alertmanager
-    upstream-source: ubuntu/prometheus-alertmanager:0.23-22.04_beta
+    upstream-source: ghcr.io/canonical/alertmanager:0.25.0
 
 provides:
   alerting:


### PR DESCRIPTION
## Issue
We are currently running Alertmanager using the upstream OCI image.

## Solution
We are now building our own ROCKs for the observability stack. We should also make sure we're using them so that effort is not in vain.

## Testing Instructions
- Deploy the charm with the new resource
- Verify functionality is still there

## Release Notes
Switch from upstream OCI image to ROCK
