### PR TITLE
add heartbeat rule for integration with cos-alerter

### DIFF
--- a/src/prometheus_alert_rules/heartbeat.rule
+++ b/src/prometheus_alert_rules/heartbeat.rule
@@ -1,0 +1,7 @@
+# Based on https://awesome-prometheus-alerts.grep.to/rules.html#prometheus-self-monitoring-1
+alert: Watchdog
+expr: vector(1)
+labels:
+  severity: none
+annotations:
+  summary: Continuously firing alert to ensure Alertmanager is working


### PR DESCRIPTION
Fixes #138 
Creates a continuously firing alert for use with cos-alerter. The severity is set to none so it should be okay to have even in the absence of cos-alerter.