### PR TITLE
use ruff instead of flake8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,9 +27,6 @@ per-file-ignores = {"tests/*" = ["D100","D101","D102","D103"]}
 [tool.ruff.pydocstyle]
 convention = "google"
 
-[tool.ruff.mccabe]
-max-complexity = 10
-
 # Static analysis tools configuration
 [tool.mypy]
 pretty = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,26 +13,22 @@ show_missing = true
 line-length = 99
 target-version = ["py38"]
 
-[tool.isort]
-profile = "black"
-
 # Linting tools configuration
-[tool.flake8]
-max-line-length = 99
-max-doc-length = 99
-max-complexity = 10
-exclude = [".git", "__pycache__", ".tox", "build", "dist", "*.egg_info", "venv"]
-select = ["E", "W", "F", "C", "N", "R", "D", "H"]
+[tool.ruff]
+line-length = 99
+extend-exclude = ["__pycache__", "*.egg_info"]
+select = ["E", "W", "F", "C", "N", "R", "D", "I001"]
 # Ignore W503, E501 because using black creates errors with this
 # Ignore D107 Missing docstring in __init__
-ignore = ["W503", "E501", "D107"]
+ignore = ["E501", "D107", "N818", "RET504"]
 # D100, D101, D102, D103: Ignore missing docstrings in tests
-per-file-ignores = ["tests/*:D100,D101,D102,D103"]
-docstring-convention = "google"
-# Check for properly formatted copyright header in each file
-copyright-check = "True"
-copyright-author = "Canonical Ltd."
-copyright-regexp = "Copyright\\s\\d{4}([-,]\\d{4})*\\s+%(author)s"
+per-file-ignores = {"tests/*" = ["D100","D101","D102","D103"]}
+
+[tool.ruff.pydocstyle]
+convention = "google"
+
+[tool.ruff.mccabe]
+max-complexity = 10
 
 # Static analysis tools configuration
 [tool.mypy]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ target-version = ["py38"]
 line-length = 99
 extend-exclude = ["__pycache__", "*.egg_info"]
 select = ["E", "W", "F", "C", "N", "R", "D", "I001"]
-# Ignore W503, E501 because using black creates errors with this
+# Ignore E501 because using black creates errors with this
 # Ignore D107 Missing docstring in __init__
 ignore = ["E501", "D107", "N818", "RET504"]
 # D100, D101, D102, D103: Ignore missing docstrings in tests

--- a/src/alertmanager_client.py
+++ b/src/alertmanager_client.py
@@ -70,7 +70,7 @@ class Alertmanager:
                 response = urllib.request.urlopen(url, data, timeout)
                 if response.code == 200 and response.reason == "OK":
                     return response.read()
-                elif retry == 0:
+                if retry == 0:
                     raise AlertmanagerBadResponse(
                         f"Bad response (code={response.code}, reason={response.reason})"
                     )

--- a/src/charm.py
+++ b/src/charm.py
@@ -13,6 +13,7 @@ from typing import List, Optional, Tuple, cast
 from urllib.parse import urlparse
 
 import yaml
+from alertmanager_client import Alertmanager, AlertmanagerBadResponse
 from charms.alertmanager_k8s.v0.alertmanager_dispatch import AlertmanagerProvider
 from charms.alertmanager_k8s.v0.alertmanager_remote_configuration import (
     RemoteConfigurationRequirer,
@@ -44,8 +45,6 @@ from ops.model import (
     WaitingStatus,
 )
 from ops.pebble import ChangeError, ExecError, Layer, PathError, ProtocolError
-
-from alertmanager_client import Alertmanager, AlertmanagerBadResponse
 
 logger = logging.getLogger(__name__)
 

--- a/tests/integration/test_config_changed_modifies_file.py
+++ b/tests/integration/test_config_changed_modifies_file.py
@@ -14,10 +14,9 @@ from pathlib import Path
 
 import pytest
 import yaml
+from alertmanager_client import Alertmanager
 from helpers import get_unit_address, is_alertmanager_up
 from pytest_operator.plugin import OpsTest
-
-from alertmanager_client import Alertmanager
 
 logger = logging.getLogger(__name__)
 

--- a/tests/integration/test_external_url.py
+++ b/tests/integration/test_external_url.py
@@ -8,10 +8,9 @@ from pathlib import Path
 
 import pytest
 import yaml
+from alertmanager_client import Alertmanager
 from helpers import get_unit_address, is_alertmanager_up
 from pytest_operator.plugin import OpsTest
-
-from alertmanager_client import Alertmanager
 
 logger = logging.getLogger(__name__)
 

--- a/tests/integration/test_persistence.py
+++ b/tests/integration/test_persistence.py
@@ -8,10 +8,9 @@ from pathlib import Path
 
 import pytest
 import yaml
+from alertmanager_client import Alertmanager
 from helpers import get_unit_address, is_alertmanager_up, uk8s_group
 from pytest_operator.plugin import OpsTest
-
-from alertmanager_client import Alertmanager
 
 logger = logging.getLogger(__name__)
 

--- a/tests/integration/test_templates.py
+++ b/tests/integration/test_templates.py
@@ -10,11 +10,10 @@ from pathlib import Path
 
 import pytest
 import yaml
+from alertmanager_client import Alertmanager
 from helpers import get_unit_address, is_alertmanager_up
 from pytest_operator.plugin import OpsTest
 from werkzeug.wrappers import Request, Response
-
-from alertmanager_client import Alertmanager
 
 logger = logging.getLogger(__name__)
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -7,12 +7,11 @@ from unittest.mock import patch
 
 import ops
 import yaml
+from charm import Alertmanager, AlertmanagerCharm
 from helpers import FakeProcessVersionCheck, k8s_resource_multipatch, tautology
 from ops import pebble
 from ops.model import ActiveStatus, BlockedStatus, Container
 from ops.testing import Harness
-
-from charm import Alertmanager, AlertmanagerCharm
 
 ops.testing.SIMULATE_CAN_CONNECT = True
 

--- a/tests/unit/test_external_url.py
+++ b/tests/unit/test_external_url.py
@@ -8,11 +8,10 @@ from unittest.mock import patch
 
 import ops
 import yaml
+from charm import Alertmanager, AlertmanagerCharm
 from helpers import FakeProcessVersionCheck, cli_arg, k8s_resource_multipatch, tautology
 from ops.model import ActiveStatus, BlockedStatus, Container
 from ops.testing import Harness
-
-from charm import Alertmanager, AlertmanagerCharm
 
 logger = logging.getLogger(__name__)
 
@@ -55,7 +54,7 @@ class TestExternalUrl(unittest.TestCase):
         plan = self.harness.get_container_pebble_plan(CONTAINER_NAME).to_dict()
         args = plan["services"][SERVICE_NAME]["command"].split()
         cluster_args = filter(lambda s: s.startswith("--cluster.peer="), args)
-        cluster_args = sorted(map(lambda s: s.split("=")[1], cluster_args))
+        cluster_args = sorted((s.split("=")[1] for s in cluster_args))
         return cluster_args
 
     def is_service_running(self) -> bool:

--- a/tests/unit/test_push_config_to_workload_on_startup.py
+++ b/tests/unit/test_push_config_to_workload_on_startup.py
@@ -10,12 +10,11 @@ import hypothesis.strategies as st
 import ops
 import validators
 import yaml
+from charm import Alertmanager, AlertmanagerCharm
 from helpers import FakeProcessVersionCheck, k8s_resource_multipatch, tautology
 from hypothesis import given
 from ops.model import ActiveStatus, BlockedStatus, Container
 from ops.testing import Harness
-
-from charm import Alertmanager, AlertmanagerCharm
 
 logger = logging.getLogger(__name__)
 ops.testing.SIMULATE_CAN_CONNECT = True

--- a/tests/unit/test_remote_configuration_requirer.py
+++ b/tests/unit/test_remote_configuration_requirer.py
@@ -8,6 +8,7 @@ from typing import cast
 from unittest.mock import Mock, PropertyMock, patch
 
 import yaml
+from charm import AlertmanagerCharm
 from charms.alertmanager_k8s.v0.alertmanager_remote_configuration import (
     DEFAULT_RELATION_NAME,
 )
@@ -15,8 +16,6 @@ from deepdiff import DeepDiff  # type: ignore[import]
 from helpers import k8s_resource_multipatch
 from ops import testing
 from ops.model import BlockedStatus
-
-from charm import AlertmanagerCharm
 
 logger = logging.getLogger(__name__)
 

--- a/tox.ini
+++ b/tox.ini
@@ -32,29 +32,21 @@ passenv =
 description = Apply coding style standards to code
 deps =
     black
-    isort
+    ruff
 commands =
-    isort {[vars]all_path}
+    ruff --fix {[vars]all_path}
     black {[vars]all_path}
 
 [testenv:lint]
 description = Check code against coding style standards
 deps =
     black
-    flake8 < 5
-    flake8-docstrings
-    flake8-copyright
-    flake8-builtins
-    pyproject-flake8
-    pep8-naming
-    isort
+    ruff
     codespell
 commands =
     codespell {[vars]lib_path}
     codespell . --skip .git --skip .tox --skip build --skip lib --skip venv --skip .mypy_cache
-    # pflake8 wrapper supports config from pyproject.toml
-    pflake8 {[vars]all_path}
-    isort --check-only --diff {[vars]all_path}
+    ruff {[vars]all_path}
     black --check --diff {[vars]all_path}
 
 [testenv:static-{charm,lib,unit,integration}]


### PR DESCRIPTION
The **flake8** plugins we use are re-implemented in **ruff**, which is why they have been removed from the dependencies.

**isort** is enabled (and used when formatting) through the `I001` rule.

The "exclude list" has been updated to omit folders that **ruff** excludes by default.

Everything else is the same, the only difference being two new rules being ignored (which weren't checked before anyway): 
* `N818: Exception name should be named with an Error suffix`, which I excluded due to the big refactoring required for it;
* `RET504: Unnecessary variable assignment before return statement`, which we do everywhere as it increases readability.