### PR TITLE
use pyright instead of mypy

### DIFF
--- a/lib/charms/alertmanager_k8s/v0/alertmanager_dispatch.py
+++ b/lib/charms/alertmanager_k8s/v0/alertmanager_dispatch.py
@@ -42,7 +42,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 6
+LIBPATCH = 7
 
 # Set to match metadata.yaml
 INTERFACE_NAME = "alertmanager_dispatch"
@@ -150,7 +150,7 @@ class AlertmanagerConsumer(RelationManagerBase):
             charm (CharmBase): consumer charm
     """
 
-    on = AlertmanagerConsumerEvents()
+    on = AlertmanagerConsumerEvents()  # pyright: ignore
 
     def __init__(self, charm: CharmBase, relation_name: str = "alerting"):
         super().__init__(charm, relation_name, RelationRole.requires)
@@ -168,7 +168,7 @@ class AlertmanagerConsumer(RelationManagerBase):
         """This hook notifies the charm that there may have been changes to the cluster."""
         if event.unit:  # event.unit may be `None` in the case of app data change
             # inform consumer about the change
-            self.on.cluster_changed.emit()
+            self.on.cluster_changed.emit()  # pyright: ignore
 
     def get_cluster_info(self) -> List[str]:
         """Returns a list of ip addresses of all the alertmanager units."""
@@ -184,12 +184,12 @@ class AlertmanagerConsumer(RelationManagerBase):
 
     def _on_relation_departed(self, _):
         """This hook notifies the charm that there may have been changes to the cluster."""
-        self.on.cluster_changed.emit()
+        self.on.cluster_changed.emit()  # pyright: ignore
 
     def _on_relation_broken(self, _):
         """This hook notifies the charm that a relation has been completely removed."""
         # inform consumer about the change
-        self.on.cluster_changed.emit()
+        self.on.cluster_changed.emit()  # pyright: ignore
 
 
 class AlertmanagerProvider(RelationManagerBase):

--- a/lib/charms/alertmanager_k8s/v0/alertmanager_remote_configuration.py
+++ b/lib/charms/alertmanager_k8s/v0/alertmanager_remote_configuration.py
@@ -38,7 +38,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 2
+LIBPATCH = 3
 
 logger = logging.getLogger(__name__)
 
@@ -137,7 +137,7 @@ class RemoteConfigurationRequirer(Object):
     `alertmanager-k8s` charm, which requires such separation.
     """
 
-    on = AlertmanagerRemoteConfigurationRequirerEvents()
+    on = AlertmanagerRemoteConfigurationRequirerEvents()  # pyright: ignore
 
     def __init__(
         self,
@@ -174,7 +174,7 @@ class RemoteConfigurationRequirer(Object):
         Emits custom `remote_configuration_changed` event every time remote configuration
         changes.
         """
-        self.on.remote_configuration_changed.emit()
+        self.on.remote_configuration_changed.emit()  # pyright: ignore
 
     def _on_relation_broken(self, _) -> None:
         """Event handler for remote configuration relation broken event.
@@ -327,7 +327,7 @@ class RemoteConfigurationProvider(Object):
     `alertmanager-k8s` charm, which requires such separation.
     """
 
-    on = AlertmanagerRemoteConfigurationProviderEvents()
+    on = AlertmanagerRemoteConfigurationProviderEvents()  # pyright: ignore
 
     def __init__(
         self,
@@ -423,7 +423,7 @@ class RemoteConfigurationProvider(Object):
         else:
             logger.warning("Invalid Alertmanager configuration. Ignoring...")
             self._clear_relation_data()
-            self.on.configuration_broken.emit()
+            self.on.configuration_broken.emit()  # pyright: ignore
 
     def _prepare_relation_data(
         self, config: Optional[dict]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,12 @@ per-file-ignores = {"tests/*" = ["D100","D101","D102","D103"]}
 convention = "google"
 
 # Static analysis tools configuration
+[tool.pyright]
+include = ["src"]
+extraPaths = ["lib"]
+pythonVersion = "3.8"
+pythonPlatform = "Linux"
+
 [tool.mypy]
 pretty = true
 python_version = 3.8

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,41 +29,9 @@ convention = "google"
 
 # Static analysis tools configuration
 [tool.pyright]
-include = ["src"]
 extraPaths = ["lib"]
 pythonVersion = "3.8"
 pythonPlatform = "Linux"
-
-[tool.mypy]
-pretty = true
-python_version = 3.8
-mypy_path = "$MYPY_CONFIG_FILE_DIR/src:$MYPY_CONFIG_FILE_DIR/lib"
-follow_imports = "normal"
-warn_redundant_casts = true
-warn_unused_ignores = false
-warn_unused_configs = true
-show_traceback = true
-show_error_codes = true
-namespace_packages = true
-explicit_package_bases = true
-check_untyped_defs = true
-allow_redefinition = true
-no_implicit_optional = false
-
-# Ignore libraries that do not have type hint nor stubs
-[[tool.mypy.overrides]]
-module = ["lightkube.*", "git.*", "validators.*"]
-ignore_missing_imports = true
-
-[[tool.mypy.overrides]]
-module = ["charms.grafana_k8s.*", "charms.traefik_k8s.*", "charms.observability_libs.*"]
-follow_imports = "silent"
-warn_unused_ignores = false
-
-[[tool.mypy.overrides]]
-module = ["ops.*", "pytest_operator.*"]
-follow_imports = "skip"
-ignore_missing_imports = true
 
 [tool.pytest.ini_options]
 minversion = "6.0"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # Copyright 2021 Canonical Ltd.
 # See LICENSE file for licensing details.
-
+sklearn
 # An implementation of the JSON Schema specification
 # Code: https://github.com/python-jsonschema/jsonschema
 # Docs: https://python-jsonschema.readthedocs.io/

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # Copyright 2021 Canonical Ltd.
 # See LICENSE file for licensing details.
-sklearn
+
 # An implementation of the JSON Schema specification
 # Code: https://github.com/python-jsonschema/jsonschema
 # Docs: https://python-jsonschema.readthedocs.io/

--- a/src/alertmanager_client.py
+++ b/src/alertmanager_client.py
@@ -31,7 +31,7 @@ class Alertmanager:
         port: int = 9093,
         *,
         web_route_prefix: str = "",
-        timeout=2.0,
+        timeout=2,
     ):
         if web_route_prefix and not web_route_prefix.endswith("/"):
             web_route_prefix += "/"

--- a/tox.ini
+++ b/tox.ini
@@ -49,27 +49,16 @@ commands =
     ruff {[vars]all_path}
     black --check --diff {[vars]all_path}
 
-[testenv:static-{charm,lib,unit,integration}]
+[testenv:static-{charm,lib}]
 description = Run static analysis checks
-setenv =
-    unit: MYPYPATH = {[vars]tst_path}/unit
-    integration: MYPYPATH = {[vars]tst_path}/integration
 deps =
-    mypy
-    types-PyYAML
-    types-requests
-    types-setuptools
-    types-toml
+    pyright
     charm: -r{toxinidir}/requirements.txt
     lib: ops
-    unit: {[testenv:unit]deps}
-    integration: {[testenv:integration]deps}
 commands =
-    charm: mypy {[vars]src_path} {posargs}
-    lib: mypy --python-version 3.5 {[vars]lib_path} {posargs}
+    charm: pyright {[vars]src_path} {posargs}
+    lib: pyright --pythonversion 3.5 {[vars]lib_path} {posargs}
     lib: /usr/bin/env sh -c 'for m in $(git diff main --name-only {[vars]lib_path}); do if ! git diff main $m | grep -q "+LIBPATCH\|+LIBAPI"; then echo "You forgot to bump the version on $m!"; exit 1; fi; done'
-    unit: mypy {[vars]tst_path}/unit {posargs}
-    integration: mypy {[vars]tst_path}/integration {posargs}
 allowlist_externals = /usr/bin/env
 
 [testenv:reqs]


### PR DESCRIPTION
Custom signals must be ignored in static checks with `# pyright: ignore` because they are only defined at runtime; **mypy** was just ignoring the entire **ops** module import, but that cannot be done with **pyright**.