### PR TITLE
Use services[x] instead of services.get(x) to fix type checking issue

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -349,7 +349,7 @@ class AlertmanagerCharm(CharmBase):
         # Update "launched with peers" flag.
         # The service should be restarted when peers joined if this is False.
         plan = self.container.get_plan()
-        service = plan.services.get(self._service_name)
+        service = plan.services[self._service_name]
         self._stored.launched_with_peers = "--cluster.peer" in service.command
 
         return True


### PR DESCRIPTION
For some reason, Pyright isn't picking up the return type of `ops.Container.get_plan` right now, so the charm is failing CI on the `tox -e static-charm` test in the ops repo. See [logs](https://github.com/canonical/operator/actions/runs/5218736817/jobs/9419804531?pr=944) -- the output of Pyright is:

```
/home/runner/work/operator/operator/src/charm.py
  /home/runner/work/operator/operator/src/charm.py:353:72 - error: "command" is not a known member of "None" (reportOptionalMemberAccess)
1 error, 0 warnings, 0 informations 
```

I haven't quite gotten to the bottom of why it happens on that repo but not on this one, but I think it has something to do with quirks in how the `Plan` type is imported in a `typing.TYPE_CHECKING` block. I can repro the failure locally, and when I take that `if typing.TYPE_CHECKING` block out, it fails on this repo just like on the ops one.

In any case, this code should use `services[name]` rather than `services.get(name)`, because the subsequent code assumes that it's non-None (accesses `service.command`).