### PR TITLE
Fix broken test due to breaking change in validators library

### DIFF
--- a/tests/unit/test_push_config_to_workload_on_startup.py
+++ b/tests/unit/test_push_config_to_workload_on_startup.py
@@ -56,7 +56,7 @@ class TestPushConfigToWorkloadOnStartup(unittest.TestCase):
         amtool_config = yaml.safe_load(
             self.harness.charm.container.pull(self.harness.charm._amtool_config_path)
         )
-        self.assertTrue(validators.url(amtool_config["alertmanager.url"]))
+        self.assertTrue(validators.url(amtool_config["alertmanager.url"], simple_host=True))
 
         # AND alertmanager config is rendered
         am_config = yaml.safe_load(

--- a/tox.ini
+++ b/tox.ini
@@ -83,7 +83,7 @@ deps =
     coverage[toml]
     deepdiff
     hypothesis
-    validators
+    validators>=0.21.2
     -r{toxinidir}/requirements.txt
     pydantic < 2.0  # from traefik_k8s.v2.ingress
 commands =


### PR DESCRIPTION
Unit tests are currently broken due to a breaking change in the validators library. See https://github.com/python-validators/validators/issues/285

Annoying, but easy to fix.