### PR TITLE
set insecure_skip_verify to False

### DIFF
--- a/src/config_builder.py
+++ b/src/config_builder.py
@@ -17,7 +17,7 @@ class ConfigError(Exception):
 
 
 default_config = {
-    "global": {"http_config": {"tls_config": {"insecure_skip_verify": True}}},
+    "global": {"http_config": {"tls_config": {"insecure_skip_verify": False}}},
     "route": {
         "group_wait": "30s",
         "group_interval": "5m",


### PR DESCRIPTION
## Issue
As part of our TLS work, we agreed to turn off `insecure_skip_verify` in all of our charms.

## Solution
Set `insecure_skip_verify` to `False` in the default config.