### PR TITLE
Fix TLS handling in the self-monitoring scrape job

### DIFF
--- a/lib/charms/grafana_k8s/v0/grafana_dashboard.py
+++ b/lib/charms/grafana_k8s/v0/grafana_dashboard.py
@@ -219,7 +219,7 @@ LIBAPI = 0
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
 
-LIBPATCH = 33
+LIBPATCH = 35
 
 logger = logging.getLogger(__name__)
 
@@ -790,7 +790,7 @@ def _inject_labels(content: str, topology: dict, transformer: "CosTool") -> str:
 
     # We need to use an index so we can insert the changed element back later
     for panel_idx, panel in enumerate(panels):
-        if type(panel) is not dict:
+        if not isinstance(panel, dict):
             continue
 
         # Use the index to insert it back in the same location
@@ -835,7 +835,7 @@ def _modify_panel(panel: dict, topology: dict, transformer: "CosTool") -> dict:
             if panel["datasource"] not in known_datasources:
                 continue
             querytype = known_datasources[panel["datasource"]]
-        elif type(panel["datasource"]) == dict:
+        elif isinstance(panel["datasource"], dict):
             if panel["datasource"]["uid"] not in known_datasources:
                 continue
             querytype = known_datasources[panel["datasource"]["uid"]]
@@ -1195,6 +1195,7 @@ class GrafanaDashboardProvider(Object):
                 `grafana_dashboaard` relationship is joined
         """
         if self._charm.unit.is_leader():
+            self._update_all_dashboards_from_dir()
             self._upset_dashboards_on_relation(event.relation)
 
     def _on_grafana_dashboard_relation_changed(self, event: RelationChangedEvent) -> None:

--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -18,13 +18,6 @@ provide a scrape target for Prometheus.
 Source code can be found on GitHub at:
  https://github.com/canonical/prometheus-k8s-operator/tree/main/lib/charms/prometheus_k8s
 
-## Dependencies
-
-Using this library requires you to fetch the juju_topology library from
-[observability-libs](https://charmhub.io/observability-libs/libraries/juju_topology).
-
-`charmcraft fetch-lib charms.observability_libs.v0.juju_topology`
-
 ## Provider Library Usage
 
 This Prometheus charm interacts with its scrape targets using its
@@ -346,7 +339,8 @@ from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 from urllib.parse import urlparse
 
 import yaml
-from charms.observability_libs.v0.juju_topology import JujuTopology
+from cosl import JujuTopology
+from cosl.rules import AlertRules
 from ops.charm import CharmBase, RelationRole
 from ops.framework import (
     BoundEvent,
@@ -368,7 +362,9 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 39
+LIBPATCH = 42
+
+PYDEPS = ["cosl"]
 
 logger = logging.getLogger(__name__)
 
@@ -608,12 +604,12 @@ class PrometheusConfig:
         return {
             "alertmanagers": [
                 {
+                    # For https we still do not render a `tls_config` section because
+                    # certs are expected to be made available by the charm via the
+                    # `update-ca-certificates` mechanism.
                     "scheme": scheme,
                     "path_prefix": path_prefix,
                     "static_configs": [{"targets": netlocs}],
-                    # FIXME figure out how to get alertmanager's ca_file into here
-                    #  Without this, prom errors: "x509: certificate signed by unknown authority"
-                    "tls_config": {"insecure_skip_verify": True},
                 }
                 for (scheme, path_prefix), netlocs in paths.items()
             ]
@@ -834,206 +830,6 @@ def _is_single_alert_rule_format(rules_dict: dict) -> bool:
     """
     # one alert rule per file
     return set(rules_dict) >= {"alert", "expr"}
-
-
-class AlertRules:
-    """Utility class for amalgamating prometheus alert rule files and injecting juju topology.
-
-    An `AlertRules` object supports aggregating alert rules from files and directories in both
-    official and single rule file formats using the `add_path()` method. All the alert rules
-    read are annotated with Juju topology labels and amalgamated into a single data structure
-    in the form of a Python dictionary using the `as_dict()` method. Such a dictionary can be
-    easily dumped into JSON format and exchanged over relation data. The dictionary can also
-    be dumped into YAML format and written directly into an alert rules file that is read by
-    Prometheus. Note that multiple `AlertRules` objects must not be written into the same file,
-    since Prometheus allows only a single list of alert rule groups per alert rules file.
-
-    The official Prometheus format is a YAML file conforming to the Prometheus documentation
-    (https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/).
-    The custom single rule format is a subsection of the official YAML, having a single alert
-    rule, effectively "one alert per file".
-    """
-
-    # This class uses the following terminology for the various parts of a rule file:
-    # - alert rules file: the entire groups[] yaml, including the "groups:" key.
-    # - alert groups (plural): the list of groups[] (a list, i.e. no "groups:" key) - it is a list
-    #   of dictionaries that have the "name" and "rules" keys.
-    # - alert group (singular): a single dictionary that has the "name" and "rules" keys.
-    # - alert rules (plural): all the alerts in a given alert group - a list of dictionaries with
-    #   the "alert" and "expr" keys.
-    # - alert rule (singular): a single dictionary that has the "alert" and "expr" keys.
-
-    def __init__(self, topology: Optional[JujuTopology] = None):
-        """Build and alert rule object.
-
-        Args:
-            topology: an optional `JujuTopology` instance that is used to annotate all alert rules.
-        """
-        self.topology = topology
-        self.tool = CosTool(None)
-        self.alert_groups = []  # type: List[dict]
-
-    def _from_file(self, root_path: Path, file_path: Path) -> List[dict]:
-        """Read a rules file from path, injecting juju topology.
-
-        Args:
-            root_path: full path to the root rules folder (used only for generating group name)
-            file_path: full path to a *.rule file.
-
-        Returns:
-            A list of dictionaries representing the rules file, if file is valid (the structure is
-            formed by `yaml.safe_load` of the file); an empty list otherwise.
-        """
-        with file_path.open() as rf:
-            # Load a list of rules from file then add labels and filters
-            try:
-                rule_file = yaml.safe_load(rf)
-
-            except Exception as e:
-                logger.error("Failed to read alert rules from %s: %s", file_path.name, e)
-                return []
-
-            if not rule_file:
-                logger.warning("Empty rules file: %s", file_path.name)
-                return []
-            if not isinstance(rule_file, dict):
-                logger.error("Invalid rules file (must be a dict): %s", file_path.name)
-                return []
-            if _is_official_alert_rule_format(rule_file):
-                alert_groups = rule_file["groups"]
-            elif _is_single_alert_rule_format(rule_file):
-                # convert to list of alert groups
-                # group name is made up from the file name
-                alert_groups = [{"name": file_path.stem, "rules": [rule_file]}]
-            else:
-                # invalid/unsupported
-                logger.error("Invalid rules file: %s", file_path.name)
-                return []
-
-            # update rules with additional metadata
-            for alert_group in alert_groups:
-                # update group name with topology and sub-path
-                alert_group["name"] = self._group_name(
-                    str(root_path),
-                    str(file_path),
-                    alert_group["name"],
-                )
-
-                # add "juju_" topology labels
-                for alert_rule in alert_group["rules"]:
-                    if "labels" not in alert_rule:
-                        alert_rule["labels"] = {}
-
-                    if self.topology:
-                        alert_rule["labels"].update(self.topology.label_matcher_dict)
-                        # insert juju topology filters into a prometheus alert rule
-                        alert_rule["expr"] = self.tool.inject_label_matchers(
-                            re.sub(r"%%juju_topology%%,?", "", alert_rule["expr"]),
-                            self.topology.label_matcher_dict,
-                        )
-
-            return alert_groups
-
-    def _group_name(self, root_path: str, file_path: str, group_name: str) -> str:
-        """Generate group name from path and topology.
-
-        The group name is made up of the relative path between the root dir_path, the file path,
-        and topology identifier.
-
-        Args:
-            root_path: path to the root rules dir.
-            file_path: path to rule file.
-            group_name: original group name to keep as part of the new augmented group name
-
-        Returns:
-            New group name, augmented by juju topology and relative path.
-        """
-        rel_path = os.path.relpath(os.path.dirname(file_path), root_path)
-        rel_path = "" if rel_path == "." else rel_path.replace(os.path.sep, "_")
-
-        # Generate group name:
-        #  - name, from juju topology
-        #  - suffix, from the relative path of the rule file;
-        group_name_parts = [self.topology.identifier] if self.topology else []
-        group_name_parts.extend([rel_path, group_name, "alerts"])
-        # filter to remove empty strings
-        return "_".join(filter(None, group_name_parts))
-
-    @classmethod
-    def _multi_suffix_glob(
-        cls, dir_path: Path, suffixes: List[str], recursive: bool = True
-    ) -> list:
-        """Helper function for getting all files in a directory that have a matching suffix.
-
-        Args:
-            dir_path: path to the directory to glob from.
-            suffixes: list of suffixes to include in the glob (items should begin with a period).
-            recursive: a flag indicating whether a glob is recursive (nested) or not.
-
-        Returns:
-            List of files in `dir_path` that have one of the suffixes specified in `suffixes`.
-        """
-        all_files_in_dir = dir_path.glob("**/*" if recursive else "*")
-        return list(filter(lambda f: f.is_file() and f.suffix in suffixes, all_files_in_dir))
-
-    def _from_dir(self, dir_path: Path, recursive: bool) -> List[dict]:
-        """Read all rule files in a directory.
-
-        All rules from files for the same directory are loaded into a single
-        group. The generated name of this group includes juju topology.
-        By default, only the top directory is scanned; for nested scanning, pass `recursive=True`.
-
-        Args:
-            dir_path: directory containing *.rule files (alert rules without groups).
-            recursive: flag indicating whether to scan for rule files recursively.
-
-        Returns:
-            a list of dictionaries representing prometheus alert rule groups, each dictionary
-            representing an alert group (structure determined by `yaml.safe_load`).
-        """
-        alert_groups = []  # type: List[dict]
-
-        # Gather all alerts into a list of groups
-        for file_path in self._multi_suffix_glob(
-            dir_path, [".rule", ".rules", ".yml", ".yaml"], recursive
-        ):
-            alert_groups_from_file = self._from_file(dir_path, file_path)
-            if alert_groups_from_file:
-                logger.debug("Reading alert rule from %s", file_path)
-                alert_groups.extend(alert_groups_from_file)
-
-        return alert_groups
-
-    def add_path(self, path: str, *, recursive: bool = False) -> None:
-        """Add rules from a dir path.
-
-        All rules from files are aggregated into a data structure representing a single rule file.
-        All group names are augmented with juju topology.
-
-        Args:
-            path: either a rules file or a dir of rules files.
-            recursive: whether to read files recursively or not (no impact if `path` is a file).
-
-        Returns:
-            True if path was added else False.
-        """
-        path = Path(path)  # type: Path
-        if path.is_dir():
-            self.alert_groups.extend(self._from_dir(path, recursive))
-        elif path.is_file():
-            self.alert_groups.extend(self._from_file(path.parent, path))
-        else:
-            logger.debug("Alert rules path does not exist: %s", path)
-
-    def as_dict(self) -> dict:
-        """Return standard alert rules file in dict representation.
-
-        Returns:
-            a dictionary containing a single list of alert rule groups.
-            The list of alert rule groups is provided as value of the
-            "groups" dictionary key.
-        """
-        return {"groups": self.alert_groups} if self.alert_groups else {}
 
 
 class TargetsChangedEvent(EventBase):
@@ -1326,7 +1122,7 @@ class MetricsEndpointConsumer(Object):
                         # Inject topology and put it back in the list
                         rule["expr"] = self._tool.inject_label_matchers(
                             re.sub(r"%%juju_topology%%,?", "", rule["expr"]),
-                            topology.label_matcher_dict,
+                            topology.alert_expression_dict,
                         )
                     except KeyError:
                         # Some required JujuTopology key is missing. Just move on.
@@ -1380,16 +1176,8 @@ class MetricsEndpointConsumer(Object):
             scrape_configs, hosts, topology
         )
 
-        # If scheme is https but no ca section present, then auto add "insecure_skip_verify",
-        # otherwise scraping errors out with "x509: certificate signed by unknown authority".
-        # https://prometheus.io/docs/prometheus/latest/configuration/configuration/#tls_config
-        for scrape_config in scrape_configs:
-            tls_config = scrape_config.get("tls_config", {})
-            ca_present = "ca" in tls_config or "ca_file" in tls_config
-            if scrape_config.get("scheme") == "https" and not ca_present:
-                tls_config["insecure_skip_verify"] = True
-                scrape_config["tls_config"] = tls_config
-
+        # For https scrape targets we still do not render a `tls_config` section because certs
+        # are expected to be made available by the charm via the `update-ca-certificates` mechanism.
         return scrape_configs
 
     def _relation_hosts(self, relation: Relation) -> Dict[str, Tuple[str, str]]:
@@ -1737,7 +1525,7 @@ class MetricsEndpointProvider(Object):
         if not self._charm.unit.is_leader():
             return
 
-        alert_rules = AlertRules(topology=self.topology)
+        alert_rules = AlertRules(query_type="promql", topology=self.topology)
         alert_rules.add_path(self._alert_rules_path, recursive=True)
         alert_rules_as_dict = alert_rules.as_dict()
 
@@ -1884,7 +1672,7 @@ class PrometheusRulesProvider(Object):
         if not self._charm.unit.is_leader():
             return
 
-        alert_rules = AlertRules()
+        alert_rules = AlertRules(query_type="promql")
         alert_rules.add_path(self.dir_path, recursive=self._recursive)
         alert_rules_as_dict = alert_rules.as_dict()
 

--- a/lib/charms/tls_certificates_interface/v2/tls_certificates.py
+++ b/lib/charms/tls_certificates_interface/v2/tls_certificates.py
@@ -276,11 +276,10 @@ import copy
 import json
 import logging
 import uuid
-from collections import defaultdict
 from contextlib import suppress
 from datetime import datetime, timedelta
 from ipaddress import IPv4Address
-from typing import Any, Dict, List, Literal, Optional
+from typing import Any, Dict, List, Literal, Optional, Union
 
 from cryptography import x509
 from cryptography.hazmat._oid import ExtensionOID
@@ -309,7 +308,7 @@ LIBAPI = 2
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 9
+LIBPATCH = 12
 
 PYDEPS = ["cryptography", "jsonschema"]
 
@@ -1062,7 +1061,7 @@ class TLSCertificatesProvidesV2(Object):
 
     def get_issued_certificates(
         self, relation_id: Optional[int] = None
-    ) -> Dict[str, Dict[str, str]]:
+    ) -> Dict[str, List[Dict[str, str]]]:
         """Returns a dictionary of issued certificates.
 
         It returns certificates from all relations if relation_id is not specified.
@@ -1071,19 +1070,30 @@ class TLSCertificatesProvidesV2(Object):
         Returns:
             dict: Certificates per application name.
         """
-        certificates: Dict[str, Dict[str, str]] = defaultdict(dict)
+        certificates: Dict[str, List[Dict[str, str]]] = {}
         relations = (
-            [self.model.relations[self.relationship_name][relation_id]]
-            if relation_id
+            [
+                relation
+                for relation in self.model.relations[self.relationship_name]
+                if relation.id == relation_id
+            ]
+            if relation_id is not None
             else self.model.relations.get(self.relationship_name, [])
         )
         for relation in relations:
             provider_relation_data = _load_relation_data(relation.data[self.charm.app])
             provider_certificates = provider_relation_data.get("certificates", [])
+
+            certificates[relation.app.name] = []  # type: ignore[union-attr]
             for certificate in provider_certificates:
-                certificates[relation.app.name].update(  # type: ignore[union-attr]
-                    {certificate["certificate_signing_request"]: certificate["certificate"]}
-                )
+                if not certificate.get("revoked", False):
+                    certificates[relation.app.name].append(  # type: ignore[union-attr]
+                        {
+                            "csr": certificate["certificate_signing_request"],
+                            "certificate": certificate["certificate"],
+                        }
+                    )
+
         return certificates
 
     def _on_relation_changed(self, event: RelationChangedEvent) -> None:
@@ -1159,6 +1169,87 @@ class TLSCertificatesProvidesV2(Object):
                 )
                 self.remove_certificate(certificate=certificate["certificate"])
 
+    def get_requirer_csrs_with_no_certs(
+        self, relation_id: Optional[int] = None
+    ) -> List[Dict[str, Union[int, str, List[Dict[str, str]]]]]:
+        """Filters the requirer's units csrs.
+
+        Keeps the ones for which no certificate was provided.
+
+        Args:
+            relation_id (int): Relation id
+
+        Returns:
+            list: List of dictionaries that contain the unit's csrs
+            that don't have a certificate issued.
+        """
+        all_unit_csr_mappings = copy.deepcopy(self.get_requirer_csrs(relation_id=relation_id))
+        for unit_csr_mapping in all_unit_csr_mappings:
+            for csr in unit_csr_mapping["unit_csrs"]:  # type: ignore[union-attr]
+                if self.certificate_issued_for_csr(
+                    app_name=unit_csr_mapping["application_name"],  # type: ignore[arg-type]
+                    csr=csr["certificate_signing_request"],  # type: ignore[index]
+                ):
+                    unit_csr_mapping["unit_csrs"].remove(csr)  # type: ignore[union-attr, arg-type]
+            if len(unit_csr_mapping["unit_csrs"]) == 0:  # type: ignore[arg-type]
+                all_unit_csr_mappings.remove(unit_csr_mapping)
+        return all_unit_csr_mappings
+
+    def get_requirer_csrs(
+        self, relation_id: Optional[int] = None
+    ) -> List[Dict[str, Union[int, str, List[Dict[str, str]]]]]:
+        """Returns a list of requirers' CSRs grouped by unit.
+
+        It returns CSRs from all relations if relation_id is not specified.
+        CSRs are returned per relation id, application name and unit name.
+
+        Returns:
+            list: List of dictionaries that contain the unit's csrs
+            with the following information
+            relation_id, application_name and unit_name.
+        """
+        unit_csr_mappings: List[Dict[str, Union[int, str, List[Dict[str, str]]]]] = []
+
+        relations = (
+            [
+                relation
+                for relation in self.model.relations[self.relationship_name]
+                if relation.id == relation_id
+            ]
+            if relation_id is not None
+            else self.model.relations.get(self.relationship_name, [])
+        )
+
+        for relation in relations:
+            for unit in relation.units:
+                requirer_relation_data = _load_relation_data(relation.data[unit])
+                unit_csrs_list = requirer_relation_data.get("certificate_signing_requests", [])
+                unit_csr_mappings.append(
+                    {
+                        "relation_id": relation.id,
+                        "application_name": relation.app.name,  # type: ignore[union-attr]
+                        "unit_name": unit.name,
+                        "unit_csrs": unit_csrs_list,
+                    }
+                )
+        return unit_csr_mappings
+
+    def certificate_issued_for_csr(self, app_name: str, csr: str) -> bool:
+        """Checks whether a certificate has been issued for a given CSR.
+
+        Args:
+            app_name (str): Application name that the CSR belongs to.
+            csr (str): Certificate Signing Request.
+
+        Returns:
+            bool: True/False depending on whether a certificate has been issued for the given CSR.
+        """
+        issued_certificates_per_csr = self.get_issued_certificates()[app_name]
+        for issued_pair in issued_certificates_per_csr:
+            if "csr" in issued_pair and issued_pair["csr"] == csr:
+                return csr_matches_certificate(csr, issued_pair["certificate"])
+        return False
+
 
 class TLSCertificatesRequiresV2(Object):
     """TLS certificates requirer class to be instantiated by TLS certificates requirers."""
@@ -1196,7 +1287,7 @@ class TLSCertificatesRequiresV2(Object):
 
     @property
     def _requirer_csrs(self) -> List[Dict[str, str]]:
-        """Returns list of requirer CSR's from relation data."""
+        """Returns list of requirer's CSRs from relation data."""
         relation = self.model.get_relation(self.relationship_name)
         if not relation:
             raise RuntimeError(f"Relation {self.relationship_name} does not exist")
@@ -1534,6 +1625,37 @@ class TLSCertificatesRequiresV2(Object):
                     certificate=certificate_dict["certificate"],
                     expiry=expiry_time.isoformat(),
                 )
+
+
+def csr_matches_certificate(csr: str, cert: str) -> bool:
+    """Check if a CSR matches a certificate.
+
+    expects to get the original string representations.
+
+    Args:
+        csr (str): Certificate Signing Request
+        cert (str): Certificate
+    Returns:
+        bool: True/False depending on whether the CSR matches the certificate.
+    """
+    try:
+        csr_object = x509.load_pem_x509_csr(csr.encode("utf-8"))
+        cert_object = x509.load_pem_x509_certificate(cert.encode("utf-8"))
+
+        if csr_object.public_key().public_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PublicFormat.SubjectPublicKeyInfo,
+        ) != cert_object.public_key().public_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PublicFormat.SubjectPublicKeyInfo,
+        ):
+            return False
+        if csr_object.subject != cert_object.subject:
+            return False
+    except ValueError:
+        logger.warning("Could not load certificate or CSR.")
+        return False
+    return True
 
 
 def _get_closest_future_time(

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -5,6 +5,9 @@ name: alertmanager-k8s
 assumes:
   - k8s-api
 
+  # Juju 3.0.3+ needed for secrets and open-port
+  - juju >= 3.0.3
+
 summary: |
   Kubernetes charm for Alertmanager.
 
@@ -33,7 +36,10 @@ containers:
 resources:
   alertmanager-image:
     type: oci-image
-    description: OCI image for alertmanager
+    description: |
+      OCI image for alertmanager. This charms makes the following assumptions about the image:
+      - location of executable "alertmanager" is in the path
+      - has `update-ca-certificates`
     upstream-source: ghcr.io/canonical/alertmanager:0.25.0
 
 provides:

--- a/src/alertmanager.py
+++ b/src/alertmanager.py
@@ -110,6 +110,7 @@ class WorkloadManager(Object):
             charm.on[snake_case_container_name].pebble_ready,
             self._on_pebble_ready,
         )
+        charm.framework.observe(charm.on.stop, self._on_stop)
 
     @property
     def is_ready(self):
@@ -123,6 +124,9 @@ class WorkloadManager(Object):
             logger.debug(
                 "Cannot set workload version at this time: could not get Alertmanager version."
             )
+
+    def _on_stop(self, _):
+        self._unit.set_workload_version("")
 
     @property
     def _alertmanager_version(self) -> Optional[str]:

--- a/src/charm.py
+++ b/src/charm.py
@@ -248,9 +248,9 @@ class AlertmanagerCharm(CharmBase):
         # x509: cannot validate certificate.
         metrics_endpoint = urlparse(self._internal_url.rstrip("/") + "/metrics")
         metrics_path = metrics_endpoint.path
-        # Render a ':port' section only if it is explicit (e.g. 9093; without a port, the port is
-        # deduced from scheme).
-        port_str = (":" + str(metrics_endpoint.port)) if metrics_endpoint.port else ""
+        # Render a ':port' section only if it is explicit (e.g. 9093; without an explicit port, the
+        # port is deduced from the scheme).
+        port_str = (":" + str(metrics_endpoint.port)) if metrics_endpoint.port is not None else ""
         target = f"{metrics_endpoint.hostname}{port_str}"
         config = {
             "scheme": metrics_endpoint.scheme,

--- a/src/charm.py
+++ b/src/charm.py
@@ -82,6 +82,7 @@ class AlertmanagerCharm(CharmBase):
 
     def __init__(self, *args):
         super().__init__(*args)
+        self.container = self.unit.get_container(self._container_name)
 
         self.server_cert = CertHandler(
             self,
@@ -97,7 +98,7 @@ class AlertmanagerCharm(CharmBase):
         self.ingress = IngressPerAppRequirer(
             self,
             port=self.api_port,
-            scheme=self._ingress_scheme,
+            scheme=lambda: urlparse(self._internal_url).scheme,
             strip_prefix=True,
             redirect_https=True,
         )
@@ -175,8 +176,6 @@ class AlertmanagerCharm(CharmBase):
             ),
         )
 
-        self.container = self.unit.get_container(self._container_name)
-
         # Core lifecycle events
         self.framework.observe(self.on.config_changed, self._on_config_changed)
 
@@ -189,7 +188,7 @@ class AlertmanagerCharm(CharmBase):
             web_external_url=self._internal_url,
             config_path=self._config_path,
             web_config_path=self._web_config_path,
-            tls_enabled=self.is_tls_enabled,
+            tls_enabled=self._is_tls_ready,
         )
         self.framework.observe(
             # The workload manager too observes pebble ready, but still need this here because
@@ -240,27 +239,26 @@ class AlertmanagerCharm(CharmBase):
         for p in new_ports_to_open:
             self.unit.open_port(p.protocol, p.port)
 
-    def _ingress_scheme(self):
-        if self.is_tls_enabled():
-            return "https"
-        return "http"
-
     @property
     def self_scraping_job(self):
         """The self-monitoring scrape job."""
-        external_url = urlparse(self._external_url)
-        metrics_path = f"{external_url.path.rstrip('/')}/metrics"
-        target = (
-            f"{external_url.hostname}{':'+str(external_url.port) if external_url.port else ''}"
-        )
-        job = {
+        # We assume that scraping, especially self-monitoring, is in-cluster.
+        # This assumption is necessary because the local CA signs CSRs with FQDN as the SAN DNS.
+        # If prometheus were to scrape an ingress URL instead, it would error out with:
+        # x509: cannot validate certificate.
+        metrics_endpoint = urlparse(self._external_url.rstrip("/") + "/metrics")
+        metrics_path = metrics_endpoint.path
+        # Render a ':port' section only if it is explicit (e.g. 9093). With ingress in place, the
+        # port is no longer needed (deduced from scheme).
+        port_str = (":" + str(metrics_endpoint.port)) if metrics_endpoint.port else ""
+        target = f"{metrics_endpoint.hostname}{port_str}"
+        config = {
+            "scheme": metrics_endpoint.scheme,
             "metrics_path": metrics_path,
             "static_configs": [{"targets": [target]}],
         }
-        if external_url.scheme == "https":
-            job["scheme"] = "https"
 
-        return [job]
+        return [config]
 
     def _resource_reqs_from_config(self) -> ResourceRequirements:
         limits = {
@@ -422,6 +420,11 @@ class AlertmanagerCharm(CharmBase):
 
         self.alertmanager_provider.update_relation_data()
 
+        self.ingress.provide_ingress_requirements(
+            scheme=urlparse(self._internal_url).scheme, port=self.api_port
+        )
+        self._scraping.update_scrape_job_spec(self.self_scraping_job)
+
         if self.peer_relation:
             # Could have simply used `socket.getfqdn()` here and add the path when reading this
             # relation data, but this way it is more future-proof in case we change from ingress
@@ -454,16 +457,6 @@ class AlertmanagerCharm(CharmBase):
 
     def _on_server_cert_changed(self, _):
         self._common_exit_hook(update_ca_certs=True)
-
-        # FIXME:
-        #  For some code ordering issue, when alertmanager is related to a CA, the relation data
-        #  sent over to traefik still has the old schema. Only with this call the schema updates to
-        #  HTTPS. To reproduce:
-        #  - Deploy alertmanager, traefik, self-signed-certificates
-        #  - Relate alertmanager to traefik first, and then to self-signed-certificates
-        #  - Look at alertmanager's app data in juju show-unit traefik/0
-        self.ingress._handle_upgrade_or_leader(None)
-        self._scraping.update_scrape_job_spec(self.self_scraping_job)
 
     def _on_pebble_ready(self, _):
         """Event handler for PebbleReadyEvent."""
@@ -547,9 +540,14 @@ class AlertmanagerCharm(CharmBase):
 
         return addresses
 
-    def is_tls_enabled(self) -> bool:
-        """Returns True if the workload is to operate / already operates in TLS mode."""
-        return bool(self.server_cert.cert)
+    def _is_tls_ready(self) -> bool:
+        """Returns True if the workload is ready to operate in TLS mode."""
+        return (
+            self.container.can_connect()
+            and self.container.exists(self._server_cert_path)
+            and self.container.exists(self._key_path)
+            and self.container.exists(self._ca_cert_path)
+        )
 
     @property
     def _internal_url(self) -> str:
@@ -557,7 +555,7 @@ class AlertmanagerCharm(CharmBase):
 
         If an external (public) url is set, add in its path.
         """
-        scheme = "https" if self.is_tls_enabled() else "http"
+        scheme = "https" if self._is_tls_ready() else "http"
         return f"{scheme}://{socket.getfqdn()}:{self._ports.api}"
 
     @property

--- a/src/charm.py
+++ b/src/charm.py
@@ -246,10 +246,10 @@ class AlertmanagerCharm(CharmBase):
         # This assumption is necessary because the local CA signs CSRs with FQDN as the SAN DNS.
         # If prometheus were to scrape an ingress URL instead, it would error out with:
         # x509: cannot validate certificate.
-        metrics_endpoint = urlparse(self._external_url.rstrip("/") + "/metrics")
+        metrics_endpoint = urlparse(self._internal_url.rstrip("/") + "/metrics")
         metrics_path = metrics_endpoint.path
-        # Render a ':port' section only if it is explicit (e.g. 9093). With ingress in place, the
-        # port is no longer needed (deduced from scheme).
+        # Render a ':port' section only if it is explicit (e.g. 9093; without a port, the port is
+        # deduced from scheme).
         port_str = (":" + str(metrics_endpoint.port)) if metrics_endpoint.port else ""
         target = f"{metrics_endpoint.hostname}{port_str}"
         config = {

--- a/tests/manual/bundle_1_e2e_tls.yaml
+++ b/tests/manual/bundle_1_e2e_tls.yaml
@@ -1,0 +1,45 @@
+bundle: kubernetes
+applications:
+  alertmanager:
+    charm: ../../alertmanager-k8s_ubuntu-20.04-amd64.charm
+    series: focal
+    resources:
+      alertmanager-image: ghcr.io/canonical/alertmanager:0.25.0
+    scale: 1
+    trust: true
+  prometheus:
+    charm: prometheus-k8s
+    channel: edge
+    scale: 1
+    trust: true
+  local-ca:
+    charm: self-signed-certificates
+    channel: edge
+    scale: 1
+  external-ca:
+    charm: self-signed-certificates
+    channel: edge
+    scale: 1
+  traefik:
+    charm: traefik-k8s
+    channel: edge
+    series: focal
+    scale: 1
+    trust: true
+relations:
+- - traefik:ingress
+  - alertmanager:ingress
+- - local-ca:send-ca-cert
+  - traefik:receive-ca-cert
+- - local-ca:certificates
+  - alertmanager:certificates
+- - local-ca:certificates
+  - prometheus:certificates
+- - traefik:certificates
+  - external-ca:certificates
+- - alertmanager:alerting
+  - prometheus:alertmanager
+- - traefik:ingress-per-unit
+  - prometheus:ingress
+- - alertmanager:self-metrics-endpoint
+  - prometheus:metrics-endpoint

--- a/tox.ini
+++ b/tox.ini
@@ -86,6 +86,7 @@ deps =
     validators>=0.21.2
     -r{toxinidir}/requirements.txt
     pydantic < 2.0  # from traefik_k8s.v2.ingress
+    cosl
 commands =
     coverage run \
       --source={[vars]src_path},{[vars]lib_path} \


### PR DESCRIPTION
## Problem
In the self-monitoring scrape job:
1. Code ordering problem: scrape URL has http instead of https after relating to ca.
2. The scrape url is an ingress URL instead of always being fqdn.

## Solution
1. Always use fqdn for self-monitoring scrape job, even when ingress is present.
2. Enable TLS only when certs/key are on disk.
3. Update scrape job and ingress spec in common exit hook to make sure we write certs on upgrade.

Drive-by fixes:
- fetch-lib.
- Clear workload version on stop.

## Testing
Deploy this bundle:
```yaml
bundle: kubernetes
applications:
  alertmanager:
    charm: ../../alertmanager-k8s_ubuntu-20.04-amd64.charm
    series: focal
    resources:
      alertmanager-image: ghcr.io/canonical/alertmanager:0.25.0
    scale: 1
    trust: true
  prometheus:
    charm: prometheus-k8s
    channel: edge
    scale: 1
    trust: true
  local-ca:
    charm: self-signed-certificates
    channel: edge
    scale: 1
  external-ca:
    charm: self-signed-certificates
    channel: edge
    scale: 1
  traefik:
    # Use traefik from https://github.com/canonical/traefik-k8s-operator/pull/245
    charm: ../../../traefik-k8s-operator/traefik-k8s_ubuntu-20.04-amd64.charm
    resources:
      traefik-image: ghcr.io/canonical/traefik:2.10.4
#    channel: edge
    series: focal
    scale: 1
    trust: true
relations:
- - traefik:ingress
  - alertmanager:ingress
- - local-ca:send-ca-cert
  - traefik:receive-ca-cert
- - local-ca:certificates
  - alertmanager:certificates
- - local-ca:certificates
  - prometheus:certificates
- - traefik:certificates
  - external-ca:certificates
- - alertmanager:alerting
  - prometheus:alertmanager
- - traefik:ingress-per-unit
  - prometheus:ingress
- - alertmanager:self-metrics-endpoint
  - prometheus:metrics-endpoint
```

Then make sure the alertmanager target is healthy:
```
curl -sk https://10.43.8.206/bndl-prometheus-0/api/v1/targets | jq | grep -E "scrapeUrl|health"
```