### PR TITLE
Always forward to prometheus the fqdn URL, not ingress

### DIFF
--- a/lib/charms/alertmanager_k8s/v1/alertmanager_dispatch.py
+++ b/lib/charms/alertmanager_k8s/v1/alertmanager_dispatch.py
@@ -25,7 +25,7 @@ class SomeApplication(CharmBase):
 ```
 """
 import logging
-from typing import List, Optional, Set
+from typing import Optional, Set
 from urllib.parse import urlparse
 
 import ops
@@ -194,25 +194,12 @@ class AlertmanagerConsumer(RelationManagerBase):
             # inform consumer about the change
             self.on.cluster_changed.emit()  # pyright: ignore
 
-    def get_cluster_info(self) -> List[str]:
-        """Returns a list of addresses of all the alertmanager units."""
-        if not (relation := self.charm.model.get_relation(self.name)):
-            return []
-
-        alertmanagers: List[str] = []
-        for unit in relation.units:
-            address = relation.data[unit].get("public_address")
-            if address:
-                alertmanagers.append(address)
-        return sorted(alertmanagers)
-
-    def get_cluster_info_with_scheme(self) -> List[str]:
-        """Returns a list of URLs of all the alertmanager units."""
+    def get_cluster_info(self) -> Set[str]:
+        """Returns a list of URLs of all alertmanager units."""
         # FIXME: in v1 of the lib:
         #  - use a dict {"url": ...} so it's extendable
-        #  - change return value to Set[str]
         if not (relation := self.charm.model.get_relation(self.name)):
-            return []
+            return set()
 
         alertmanagers: Set[str] = set()
         for unit in relation.units:
@@ -220,7 +207,7 @@ class AlertmanagerConsumer(RelationManagerBase):
             scheme = relation.data[unit].get("scheme", "http")
             if address:
                 alertmanagers.add(f"{scheme}://{address}")
-        return sorted(alertmanagers)
+        return alertmanagers
 
     def _on_relation_departed(self, _):
         """This hook notifies the charm that there may have been changes to the cluster."""

--- a/src/alertmanager.py
+++ b/src/alertmanager.py
@@ -7,7 +7,7 @@
 import logging
 import re
 from typing import Callable, Dict, List, Optional, Tuple
-
+import os
 from alertmanager_client import Alertmanager, AlertmanagerBadResponse
 from ops.framework import Object
 from ops.model import Container
@@ -193,6 +193,13 @@ class WorkloadManager(Object):
                 f"{peer_cmd_args}"
             )
 
+        def _environment():
+            return {
+                "https_proxy": os.environ.get("JUJU_CHARM_HTTPS_PROXY", ""),
+                "http_proxy": os.environ.get("JUJU_CHARM_HTTP_PROXY", ""),
+                "no_proxy": os.environ.get("JUJU_CHARM_NO_PROXY", ""),
+            }
+
         return Layer(
             {
                 "summary": "alertmanager layer",
@@ -203,6 +210,7 @@ class WorkloadManager(Object):
                         "summary": "alertmanager service",
                         "command": _command(),
                         "startup": "enabled",
+                        "environment": _environment(),
                     }
                 },
             }

--- a/src/alertmanager.py
+++ b/src/alertmanager.py
@@ -5,9 +5,10 @@
 """Workload manager for alertmanaqger."""
 
 import logging
+import os
 import re
 from typing import Callable, Dict, List, Optional, Tuple
-import os
+
 from alertmanager_client import Alertmanager, AlertmanagerBadResponse
 from ops.framework import Object
 from ops.model import Container

--- a/tests/manual/bundle_1_e2e_tls.yaml
+++ b/tests/manual/bundle_1_e2e_tls.yaml
@@ -12,6 +12,16 @@ applications:
     channel: edge
     scale: 1
     trust: true
+  avalanche:
+    # The avalanche charm has always-firing alerts that can be used to verify prometheus is able to
+    # post alerts to alertmanager.
+    charm: avalanche-k8s
+    channel: edge
+    scale: 1
+    trust: true
+    options:
+      metric_count: 10
+      series_count: 2
   local-ca:
     charm: self-signed-certificates
     channel: edge
@@ -42,4 +52,6 @@ relations:
 - - traefik:ingress-per-unit
   - prometheus:ingress
 - - alertmanager:self-metrics-endpoint
+  - prometheus:metrics-endpoint
+- - avalanche:metrics-endpoint
   - prometheus:metrics-endpoint

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -73,6 +73,7 @@ class TestWithInitialHooks(unittest.TestCase):
         assert rel is not None  # for static checker
         expected_address = "fqdn:{}".format(self.harness.charm.api_port)
         expected_rel_data = {
+            "url": "http://fqdn:9093",
             "public_address": expected_address,
             "scheme": "http",
         }

--- a/tests/unit/test_consumer.py
+++ b/tests/unit/test_consumer.py
@@ -6,7 +6,7 @@ import textwrap
 import unittest
 
 import ops
-from charms.alertmanager_k8s.v0.alertmanager_dispatch import AlertmanagerConsumer
+from charms.alertmanager_k8s.v1.alertmanager_dispatch import AlertmanagerConsumer
 from ops.charm import CharmBase
 from ops.framework import StoredState
 from ops.testing import Harness

--- a/tests/unit/test_consumer.py
+++ b/tests/unit/test_consumer.py
@@ -79,7 +79,7 @@ class TestConsumer(unittest.TestCase):
 
     def test_cluster_updated_after_alertmanager_units_join(self):
         # before
-        self.assertEqual([], self.harness.charm.alertmanager_lib.get_cluster_info())
+        self.assertEqual(set(), self.harness.charm.alertmanager_lib.get_cluster_info())
         num_events = self.harness.charm._stored.cluster_changed_emitted
 
         # add relation
@@ -88,8 +88,9 @@ class TestConsumer(unittest.TestCase):
 
         # after
         self.assertGreater(self.harness.charm._stored.cluster_changed_emitted, num_events)
-        self.assertListEqual(
-            ["10.20.30.0", "10.20.30.1"], self.harness.charm.alertmanager_lib.get_cluster_info()
+        self.assertSetEqual(
+            {"http://10.20.30.0", "http://10.20.30.1"},
+            self.harness.charm.alertmanager_lib.get_cluster_info(),
         )
 
         num_events = self.harness.charm._stored.cluster_changed_emitted
@@ -97,8 +98,8 @@ class TestConsumer(unittest.TestCase):
         # add another unit
         self._add_alertmanager_units(rel_id, num_units=1, start_with=2)
         self.assertGreater(self.harness.charm._stored.cluster_changed_emitted, num_events)
-        self.assertListEqual(
-            ["10.20.30.0", "10.20.30.1", "10.20.30.2"],
+        self.assertSetEqual(
+            {"http://10.20.30.0", "http://10.20.30.1", "http://10.20.30.2"},
             self.harness.charm.alertmanager_lib.get_cluster_info(),
         )
 
@@ -119,7 +120,7 @@ class TestConsumer(unittest.TestCase):
         self.harness.remove_relation_unit(rel_id, "am/2")
         self.assertGreater(self.harness.charm._stored.cluster_changed_emitted, num_events)
         after = self.harness.charm.alertmanager_lib.get_cluster_info()
-        self.assertListEqual(after, ["10.20.30.0", "10.20.30.1"])
+        self.assertSetEqual(after, {"http://10.20.30.0", "http://10.20.30.1"})
 
         num_events = self.harness.charm._stored.cluster_changed_emitted
 
@@ -129,7 +130,7 @@ class TestConsumer(unittest.TestCase):
         self.assertGreater(self.harness.charm._stored.cluster_changed_emitted, num_events)
         after = self.harness.charm.alertmanager_lib.get_cluster_info()
         self.assertGreater(self.harness.charm._stored.cluster_changed_emitted, num_events)
-        self.assertListEqual(after, [])
+        self.assertSetEqual(after, set())
 
     def test_cluster_is_empty_after_relation_breaks(self):
         # add relation
@@ -144,7 +145,7 @@ class TestConsumer(unittest.TestCase):
         self.harness.remove_relation(rel_id)
         after = self.harness.charm.alertmanager_lib.get_cluster_info()
         self.assertGreater(self.harness.charm._stored.cluster_changed_emitted, num_events)
-        self.assertListEqual([], after)
+        self.assertSetEqual(set(), after)
 
     def test_relation_changed(self):
         # add relation
@@ -153,6 +154,7 @@ class TestConsumer(unittest.TestCase):
 
         # update remote unit's relation data (emulates upgrade-charm)
         self.harness.update_relation_data(rel_id, "am/1", {"public_address": "90.80.70.60"})
-        self.assertListEqual(
-            ["10.20.30.0", "90.80.70.60"], self.harness.charm.alertmanager_lib.get_cluster_info()
+        self.assertSetEqual(
+            {"http://10.20.30.0", "http://90.80.70.60"},
+            self.harness.charm.alertmanager_lib.get_cluster_info(),
         )

--- a/tox.ini
+++ b/tox.ini
@@ -55,6 +55,7 @@ deps =
     pyright
     charm: -r{toxinidir}/requirements.txt
     lib: ops
+    pydantic < 2.0  # from alertmanager_k8s.v1.alertmanager_dispatch
 setenv =
     PYRIGHT_PYTHON_FORCE_VERSION = latest
 commands =


### PR DESCRIPTION
## Problem
`alertmanager_dispatch` forwards ingress url to prometheus, but prometheus may not have a cert in place to trust the ca that signed the ingress provider (traefik).

## Solution
Forward the k8s fqdn, until https://github.com/canonical/operator/issues/970 is impl'd.

Fixes #194.

Drive-by fixes:
- Improve provider API, and bump LIBAPI to 1.
- Incorporate proxy envvars from #180.

## Testing
Deploy the manual testing bundle, [bundle_1_e2e_tls.yaml](https://github.com/canonical/alertmanager-k8s-operator/blob/main/tests/manual/bundle_1_e2e_tls.yaml), and make sure prometheus was able to post alerts to alertmanager:
```
$ curl -k https://10.1.166.69:9093/api/v2/alerts
[{"annotations":{"description":"test_09f2c30f- ... and so it goes
```