### PR TITLE
use major version for rock tag

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -40,7 +40,7 @@ resources:
       OCI image for alertmanager. This charms makes the following assumptions about the image:
       - location of executable "alertmanager" is in the path
       - has `update-ca-certificates`
-    upstream-source: ubuntu/alertmanager:0.25.0-22.04_stable
+    upstream-source: ubuntu/alertmanager:0-22.04
 
 provides:
   alerting:


### PR DESCRIPTION
We should set the base image to track the major version tag for the ROCK; on a charm release, it will be fixed to the digest of the current latest image with the same major version.