### PR TITLE
Fix config reload when TLS is enabled

### DIFF
--- a/src/alertmanager.py
+++ b/src/alertmanager.py
@@ -99,7 +99,7 @@ class WorkloadManager(Object):
 
         self._api_port = api_port
         self._ha_port = ha_port
-        self.api = Alertmanager(endpoint_url=charm._external_url)
+        self.api = Alertmanager(endpoint_url=web_external_url)
         self._web_external_url = web_external_url
         self._config_path = config_path
         self._web_config_path = web_config_path

--- a/src/alertmanager.py
+++ b/src/alertmanager.py
@@ -86,6 +86,7 @@ class WorkloadManager(Object):
         config_path: str,
         web_config_path: str,
         tls_enabled: Callable[[], bool],
+        cafile: Optional[str],
     ):
         # Must inherit from ops 'Object' to be able to register events.
         super().__init__(charm, f"{self.__class__.__name__}-{container_name}")
@@ -99,7 +100,7 @@ class WorkloadManager(Object):
 
         self._api_port = api_port
         self._ha_port = ha_port
-        self.api = Alertmanager(endpoint_url=web_external_url)
+        self.api = Alertmanager(endpoint_url=web_external_url, cafile=cafile)
         self._web_external_url = web_external_url
         self._config_path = config_path
         self._web_config_path = web_config_path

--- a/src/alertmanager_client.py
+++ b/src/alertmanager_client.py
@@ -6,6 +6,7 @@
 
 import json
 import logging
+import ssl
 import time
 import urllib.error
 import urllib.parse
@@ -60,9 +61,14 @@ class Alertmanager:
         Raises:
             AlertmanagerBadResponse: If no response or invalid response, regardless the reason.
         """
+        # TODO: pass cert instead of insecure skip verify
+        ctx = ssl.create_default_context()
+        ctx.check_hostname = False
+        ctx.verify_mode = ssl.CERT_NONE
+
         for retry in reversed(range(3)):
             try:
-                response = urllib.request.urlopen(url, data, timeout)
+                response = urllib.request.urlopen(url, data, timeout, context=ctx)
                 if response.code == 200 and response.reason == "OK":
                     return response.read()
                 if retry == 0:

--- a/src/alertmanager_client.py
+++ b/src/alertmanager_client.py
@@ -30,9 +30,12 @@ class Alertmanager:
         self,
         endpoint_url: str = "http://localhost:9093",
         timeout=2,
+        cafile: Optional[str] = None,
     ):
         self.base_url = endpoint_url.rstrip("/")
         self.timeout = timeout
+
+        self.ssl_context = ssl.create_default_context(cafile=cafile)
 
     def reload(self) -> bool:
         """Send a POST request to hot-reload the config.
@@ -49,8 +52,7 @@ class Alertmanager:
             return False
         return True
 
-    @staticmethod
-    def _open(url: str, data: Optional[bytes], timeout: float) -> bytes:
+    def _open(self, url: str, data: Optional[bytes], timeout: float) -> bytes:
         """Send a request using urlopen.
 
         Args:
@@ -61,14 +63,9 @@ class Alertmanager:
         Raises:
             AlertmanagerBadResponse: If no response or invalid response, regardless the reason.
         """
-        # TODO: pass cert instead of insecure skip verify
-        ctx = ssl.create_default_context()
-        ctx.check_hostname = False
-        ctx.verify_mode = ssl.CERT_NONE
-
         for retry in reversed(range(3)):
             try:
-                response = urllib.request.urlopen(url, data, timeout, context=ctx)
+                response = urllib.request.urlopen(url, data, timeout, context=self.ssl_context)
                 if response.code == 200 and response.reason == "OK":
                     return response.read()
                 if retry == 0:


### PR DESCRIPTION
## Problem
With TLS enabled, the POST method on `/-/reload` is failing.

Related: #58

## Solution
- Use internal url instead of external url. Otherwise we'd need to have the external ca cert.
- Use proper tls [context](https://docs.python.org/3/library/ssl.html#ssl.create_default_context).

Fixes #207.

## Upgrade notes
To upgrade from an older revision of charmed alertmanager, you may need to re-relate the tls-certificates relation to the local CA, or manually copy `/usr/local/share/ca-certificates/cos-ca.crt` from the `alertmanager` to the `charm` container.
