### PR TITLE
Correct use of property

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -283,7 +283,7 @@ class AlertmanagerCharm(CharmBase):
     def _on_show_config_action(self, event: ActionEvent):
         """Hook for the show-config action."""
         event.log(f"Fetching {self._config_path}")
-        if not self.alertmanager_workload.is_ready():
+        if not self.alertmanager_workload.is_ready:
             event.fail("Container not ready")
 
         filepaths = self._render_manifest().manifest.keys()


### PR DESCRIPTION
## Problem
`workload.is_ready` is a property but used as a callable in charm code, resulting in:

```
juju run alertmanager/0 show-config

2024-02-07T14:32:19.610Z [container-agent] 2024-02-07 14:32:19 DEBUG juju-log Emitting Juju event show_config_action.
2024-02-07T14:32:19.654Z [container-agent] 2024-02-07 14:32:19 ERROR juju-log Uncaught exception while in charm code:
2024-02-07T14:32:19.654Z [container-agent] Traceback (most recent call last):
2024-02-07T14:32:19.654Z [container-agent]   File "./src/charm.py", line 572, in <module>
2024-02-07T14:32:19.654Z [container-agent]     main(AlertmanagerCharm)
2024-02-07T14:32:19.654Z [container-agent]   File "/var/lib/juju/agents/unit-alertmanager-0/charm/venv/ops/main.py", line 441, in main
2024-02-07T14:32:19.654Z [container-agent]     _emit_charm_event(charm, dispatcher.event_name)
2024-02-07T14:32:19.654Z [container-agent]   File "/var/lib/juju/agents/unit-alertmanager-0/charm/venv/ops/main.py", line 149, in _emit_charm_event
2024-02-07T14:32:19.654Z [container-agent]     event_to_emit.emit(*args, **kwargs)
2024-02-07T14:32:19.654Z [container-agent]   File "/var/lib/juju/agents/unit-alertmanager-0/charm/venv/ops/framework.py", line 344, in emit
2024-02-07T14:32:19.654Z [container-agent]     framework._emit(event)
2024-02-07T14:32:19.654Z [container-agent]   File "/var/lib/juju/agents/unit-alertmanager-0/charm/venv/ops/framework.py", line 833, in _emit
2024-02-07T14:32:19.654Z [container-agent]     self._reemit(event_path)
2024-02-07T14:32:19.654Z [container-agent]   File "/var/lib/juju/agents/unit-alertmanager-0/charm/venv/ops/framework.py", line 922, in _reemit
2024-02-07T14:32:19.654Z [container-agent]     custom_handler(event)
2024-02-07T14:32:19.654Z [container-agent]   File "./src/charm.py", line 286, in _on_show_config_action
2024-02-07T14:32:19.654Z [container-agent]     if not self.alertmanager_workload.is_ready():
2024-02-07T14:32:19.654Z [container-agent] TypeError: 'bool' object is not callable
```

## Solution
Drop the `()`.

Fixes #216.