### PR TITLE
bump python version in static-lib to 3.8

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -58,7 +58,7 @@ setenv =
     PYRIGHT_PYTHON_FORCE_VERSION = latest
 commands =
     charm: pyright {[vars]src_path} {posargs}
-    lib: pyright --pythonversion 3.5 {[vars]lib_path} {posargs}
+    lib: pyright --pythonversion 3.8 {[vars]lib_path} {posargs}
     lib: /usr/bin/env sh -c 'for m in $(git diff main --name-only {[vars]lib_path}); do if ! git diff main $m | grep -q "+LIBPATCH\|+LIBAPI"; then echo "You forgot to bump the version on $m!"; exit 1; fi; done'
 allowlist_externals = /usr/bin/env
 


### PR DESCRIPTION
We're currently doing the **static-lib** check on the alertmanager library using python 3.5, but that's now making CI fail.

I don't think there's any reason why we would do that, so I'm fixing it to 3.8, just like all the other charms do :)