### PR TITLE
Don't use non-existent webhook as a placeholder

### DIFF
--- a/src/config_builder.py
+++ b/src/config_builder.py
@@ -24,7 +24,7 @@ default_config = {
         "repeat_interval": "1h",
         "receiver": "placeholder",
     },
-    "receivers": [{"name": "placeholder", "webhook_configs": [{"url": "http://127.0.0.1:5001/"}]}],
+    "receivers": [{"name": "placeholder"}],
 }
 
 


### PR DESCRIPTION
## Issue

Fixes: #237

## Solution

The fake webhook fires the AlertmanagerNotificationsFailed alert continuously out of the box. Instead, use a blackhole receiver without any backend as a placeholder when no receiver is provided by an operator.

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->

[before patching]
```yaml
global:
  http_config:
    tls_config:
      insecure_skip_verify: false
receivers:
- name: placeholder
  webhook_configs:
  - url: http://127.0.0.1:5001/
route:
  group_by:
  - juju_model
  - juju_application
  - juju_model_uuid
  group_interval: 5m
  group_wait: 30s
  receiver: placeholder
  repeat_interval: 1h
```

[after patching]
```yaml
global:
  http_config:
    tls_config:
      insecure_skip_verify: false
receivers:
- name: placeholder
route:
  group_by:
  - juju_application
  - juju_model
  - juju_model_uuid
  group_interval: 5m
  group_wait: 30s
  receiver: placeholder
  repeat_interval: 1h
```


[After patching]
![Screenshot from 2024-03-19 12-00-18](https://github.com/canonical/alertmanager-k8s-operator/assets/4356209/a3b94e2f-c396-42b5-92c2-c7469dc84655)

[The fix was applied in the middle of this timeline]
![Screenshot from 2024-03-19 11-56-56](https://github.com/canonical/alertmanager-k8s-operator/assets/4356209/aecc6cb8-7628-4ee5-99b6-d1f617939463)


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->

The steps are in #237.
1. deploy COS and workload
2. related COS with workload
3. check alerts

## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->

N/A