### PR TITLE
Fix client tls

### DIFF
--- a/src/alertmanager_client.py
+++ b/src/alertmanager_client.py
@@ -19,7 +19,7 @@ import yaml
 logger = logging.getLogger(__name__)
 
 
-class AlertmanagerBadResponse(RuntimeError):
+class AlertmanagerBadResponse(ConnectionError):
     """A catch-all exception type to indicate 'no reply', regardless the reason."""
 
 

--- a/tests/integration/test_persistence.py
+++ b/tests/integration/test_persistence.py
@@ -26,7 +26,10 @@ async def test_silences_persist_across_upgrades(ops_test: OpsTest, charm_under_t
     await ops_test.model.deploy(
         "ch:alertmanager-k8s", application_name=app_name, channel="edge", trust=True
     )
-    await ops_test.model.wait_for_idle(apps=[app_name], status="active", timeout=1000)
+    await ops_test.model.wait_for_idle(
+        apps=[app_name], status="active", timeout=1000, raise_on_error=False
+    )
+    await ops_test.model.wait_for_idle(apps=[app_name], status="active", timeout=30)
 
     # set a silencer for an alert and check it is set
     unit_address = await get_unit_address(ops_test, app_name, 0)

--- a/tests/integration/test_templates.py
+++ b/tests/integration/test_templates.py
@@ -121,7 +121,7 @@ async def test_receiver_gets_alert(ops_test: OpsTest, httpserver):
                 "status=firing",
                 "juju_model_uuid=1234",
                 f"juju_application={app_name}",
-                f"juju_model=model_name",
+                "juju_model=model_name",
                 "--annotation=summary=summary",
             ]
         )

--- a/tests/integration/test_upgrade_charm.py
+++ b/tests/integration/test_upgrade_charm.py
@@ -71,7 +71,7 @@ async def test_upgrade_local_with_local_with_relations(ops_test: OpsTest, charm_
     # Refresh from path
     await ops_test.model.applications[app_name].refresh(path=charm_under_test, resources=resources)
     await ops_test.model.wait_for_idle(
-        apps=[app_name, "prom", "karma"], status="active", timeout=2500
+        apps=[app_name, "prom", "karma"], status="active", timeout=2500, raise_on_error=False,
     )
     assert await is_alertmanager_up(ops_test, app_name)
 

--- a/tests/integration/test_upgrade_charm.py
+++ b/tests/integration/test_upgrade_charm.py
@@ -71,7 +71,10 @@ async def test_upgrade_local_with_local_with_relations(ops_test: OpsTest, charm_
     # Refresh from path
     await ops_test.model.applications[app_name].refresh(path=charm_under_test, resources=resources)
     await ops_test.model.wait_for_idle(
-        apps=[app_name, "prom", "karma"], status="active", timeout=2500, raise_on_error=False,
+        apps=[app_name, "prom", "karma"],
+        status="active",
+        timeout=2500,
+        raise_on_error=False,
     )
     assert await is_alertmanager_up(ops_test, app_name)
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -9,7 +9,7 @@ import ops
 import yaml
 from alertmanager import WorkloadManager
 from charm import AlertmanagerCharm
-from helpers import k8s_resource_multipatch, tautology
+from helpers import k8s_resource_multipatch
 from ops import pebble
 from ops.model import ActiveStatus, BlockedStatus
 from ops.testing import Harness

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -8,7 +8,7 @@ from unittest.mock import patch
 import ops
 import yaml
 from alertmanager import WorkloadManager
-from charm import Alertmanager, AlertmanagerCharm
+from charm import AlertmanagerCharm
 from helpers import k8s_resource_multipatch, tautology
 from ops import pebble
 from ops.model import ActiveStatus, BlockedStatus
@@ -20,7 +20,6 @@ ops.testing.SIMULATE_CAN_CONNECT = True
 class TestWithInitialHooks(unittest.TestCase):
     container_name: str = "alertmanager"
 
-    @patch.object(Alertmanager, "reload", tautology)
     @patch.object(WorkloadManager, "check_config", lambda *a, **kw: ("ok", ""))
     @patch("socket.getfqdn", new=lambda *args: "fqdn")
     @k8s_resource_multipatch
@@ -151,7 +150,6 @@ class TestWithInitialHooks(unittest.TestCase):
 class TestWithoutInitialHooks(unittest.TestCase):
     container_name: str = "alertmanager"
 
-    @patch.object(Alertmanager, "reload", tautology)
     @patch.object(WorkloadManager, "check_config", lambda *a, **kw: ("ok", ""))
     @k8s_resource_multipatch
     @patch("lightkube.core.client.GenericSyncClient")

--- a/tests/unit/test_external_url.py
+++ b/tests/unit/test_external_url.py
@@ -9,7 +9,7 @@ from unittest.mock import patch
 import ops
 import yaml
 from alertmanager import WorkloadManager
-from charm import Alertmanager, AlertmanagerCharm
+from charm import AlertmanagerCharm
 from helpers import cli_arg, k8s_resource_multipatch, tautology
 from ops.testing import Harness
 
@@ -21,7 +21,6 @@ SERVICE_NAME = AlertmanagerCharm._service_name
 
 
 class TestExternalUrl(unittest.TestCase):
-    @patch.object(Alertmanager, "reload", tautology)
     @patch.object(WorkloadManager, "check_config", lambda *a, **kw: ("ok", ""))
     @patch("socket.getfqdn", new=lambda *args: "fqdn")
     @k8s_resource_multipatch

--- a/tests/unit/test_external_url.py
+++ b/tests/unit/test_external_url.py
@@ -10,7 +10,7 @@ import ops
 import yaml
 from alertmanager import WorkloadManager
 from charm import AlertmanagerCharm
-from helpers import cli_arg, k8s_resource_multipatch, tautology
+from helpers import cli_arg, k8s_resource_multipatch
 from ops.testing import Harness
 
 logger = logging.getLogger(__name__)

--- a/tests/unit/test_push_config_to_workload_on_startup.py
+++ b/tests/unit/test_push_config_to_workload_on_startup.py
@@ -12,7 +12,7 @@ import validators
 import yaml
 from alertmanager import WorkloadManager
 from charm import AlertmanagerCharm
-from helpers import k8s_resource_multipatch, tautology
+from helpers import k8s_resource_multipatch
 from hypothesis import given
 from ops.model import ActiveStatus, BlockedStatus
 from ops.testing import Harness

--- a/tests/unit/test_push_config_to_workload_on_startup.py
+++ b/tests/unit/test_push_config_to_workload_on_startup.py
@@ -11,7 +11,7 @@ import ops
 import validators
 import yaml
 from alertmanager import WorkloadManager
-from charm import Alertmanager, AlertmanagerCharm
+from charm import AlertmanagerCharm
 from helpers import k8s_resource_multipatch, tautology
 from hypothesis import given
 from ops.model import ActiveStatus, BlockedStatus
@@ -29,7 +29,6 @@ class TestPushConfigToWorkloadOnStartup(unittest.TestCase):
     Background: Charm starts up with initial hooks.
     """
 
-    @patch.object(Alertmanager, "reload", tautology)
     @patch.object(WorkloadManager, "check_config", lambda *a, **kw: ("0.0.0", ""))
     @k8s_resource_multipatch
     @patch("lightkube.core.client.GenericSyncClient")
@@ -118,7 +117,6 @@ class TestInvalidConfig(unittest.TestCase):
         self.harness = Harness(AlertmanagerCharm)
         self.addCleanup(self.harness.cleanup)
 
-    @patch.object(Alertmanager, "reload", tautology)
     @k8s_resource_multipatch
     @patch("lightkube.core.client.GenericSyncClient")
     @patch.object(WorkloadManager, "_alertmanager_version", property(lambda *_: "0.0.0"))
@@ -132,7 +130,6 @@ class TestInvalidConfig(unittest.TestCase):
         # THEN the charm goes into blocked status
         self.assertIsInstance(self.harness.charm.unit.status, BlockedStatus)
 
-    @patch.object(Alertmanager, "reload", tautology)
     @k8s_resource_multipatch
     @patch("lightkube.core.client.GenericSyncClient")
     @patch.object(WorkloadManager, "_alertmanager_version", property(lambda *_: "0.0.0"))

--- a/tox.ini
+++ b/tox.ini
@@ -123,6 +123,7 @@ deps =
     pytest
     pytest-operator
     pytest-httpserver
+    sh
 commands =
     pytest -v --tb native --log-cli-level=INFO -s {posargs} {toxinidir}/tests/integration
 


### PR DESCRIPTION
## Issue
In an [itest](https://github.com/canonical/cos-lite-bundle/actions/runs/8369278492/job/22914758721#step:6:567), alertmanager produced `Failed to obtain status: Bad response`.

This is because the "api" was instantiated without the ca_file.

## Solution
Remove leftovers of the old `self.api` and use instead `self.workload.api`, which already has the ca_file.
