### PR TITLE
fix: tell type checkers that the config options are strings

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -9,7 +9,7 @@ import socket
 import subprocess
 from pathlib import Path
 from types import SimpleNamespace
-from typing import List, Optional, Tuple
+from typing import List, Optional, Tuple, cast
 from urllib.parse import urlparse
 
 import yaml
@@ -338,8 +338,8 @@ class AlertmanagerCharm(CharmBase):
     def _get_local_config(self) -> Optional[Tuple[Optional[dict], Optional[str]]]:
         config = self.config["config_file"]
         if config:
-            local_config = yaml.safe_load(config)
-            local_templates = self.config["templates_file"] or None
+            local_config = yaml.safe_load(cast(str, config))
+            local_templates = cast(str, self.config["templates_file"]) or None
             return local_config, local_templates
         return None
 


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->

ops<=2.12 wrongly has `self.config[x]` typed as `str`, when actually it could be an int, float, bool, or str, depending on the config type. We're fixing this in [ops:#1183](https://github.com/canonical/operator/pull/1183), but that will break static checking that currently assumes that the config is a str (because ops doesn't validate the schema, so all options will be bool|int|float|str).

## Solution
<!-- A summary of the solution addressing the above issue -->

Two `typing.cast` calls where the config values are loaded and used where the type should be str.

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->

Covered above.

## Testing Instructions
<!-- What steps need to be taken to test this PR? -->

Run `tox -e static-charm` with/without the PR with ops 2.12 and with either the PR branch linked above or once that's merged ops main/2.13.

## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->

N/A