### PR TITLE
make server cert path return None if tls disabled

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -583,7 +583,7 @@ class AlertmanagerCharm(CharmBase):
     @property
     def server_cert_path(self) -> Optional[str]:
         """Server certificate path for tls tracing."""
-        return self._server_cert_path
+        return self._server_cert_path if self.server_cert.enabled else None
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
title says it all

charm tracing expects Optional[str], where None means: there's no TLS, and str means: here's your cert.
Alertmanager is returning str even though the file doesn't exist, which makes charm-tracing log exceptions on every hook.