### PR TITLE
fix: pin codespell to 2.3.0

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -42,7 +42,7 @@ description = Check code against coding style standards
 deps =
     black
     ruff
-    codespell
+    codespell<2.3.0 # https://github.com/codespell-project/codespell/issues/3430
 commands =
     codespell {[vars]lib_path}
     codespell . --skip .git --skip .tox --skip build --skip lib --skip venv --skip .mypy_cache


### PR DESCRIPTION
## Issue
CI on main is failing due to an issue in `codespell` which fails on `assertIn => asserting`. This PR temporarily pins it to avoid the linting error.