### PR TITLE
Treat ellipsis correctly

### DIFF
--- a/src/config_builder.py
+++ b/src/config_builder.py
@@ -99,9 +99,10 @@ class ConfigBuilder:
         # add juju topology to "group_by"
         # `route` is a mandatory field so don't need to be too careful
         route = config.get("route", {})
-        group_by = route.get("group_by", [])
-        group_by = list(set(group_by).union(["juju_application", "juju_model", "juju_model_uuid"]))
-        route["group_by"] = group_by
+        group_by = set(route.get("group_by", []))
+        if group_by != {"..."}:
+            group_by = list(group_by.union(["juju_application", "juju_model", "juju_model_uuid"]))
+        route["group_by"] = list(group_by)
         config["route"] = route
         return yaml.safe_dump(config)
 

--- a/src/config_builder.py
+++ b/src/config_builder.py
@@ -100,6 +100,9 @@ class ConfigBuilder:
         # `route` is a mandatory field so don't need to be too careful
         route = config.get("route", {})
         group_by = set(route.get("group_by", []))
+
+        # The special value '...' disables aggregation entirely. Do not add topology in that case.
+        # Ref: https://prometheus.io/docs/alerting/latest/configuration/#route
         if group_by != {"..."}:
             group_by = list(group_by.union(["juju_application", "juju_model", "juju_model_uuid"]))
         route["group_by"] = list(group_by)


### PR DESCRIPTION
## Issue
Config file is built disregarding the special meaning of the ellipsis in group_by.
[Ref](https://prometheus.io/docs/alerting/latest/configuration/#route).

## Solution
Do not add topology into group_by if the user provided config has an ellipsis. 

Fixes #205.

