### PR TITLE
add ingress refresh events to grafana source

### DIFF
--- a/lib/charms/tempo_k8s/v1/charm_tracing.py
+++ b/lib/charms/tempo_k8s/v1/charm_tracing.py
@@ -9,21 +9,57 @@
 This means that, if your charm is related to, for example, COS' Tempo charm, you will be able to inspect
 in real time from the Grafana dashboard the execution flow of your charm.
 
-To start using this library, you need to do two things:
+# Quickstart
+Fetch the following charm libs (and ensure the minimum version/revision numbers are satisfied):
+
+    charmcraft fetch-lib charms.tempo_k8s.v2.tracing  # >= 1.10
+    charmcraft fetch-lib charms.tempo_k8s.v1.charm_tracing  # >= 2.7
+
+Then edit your charm code to include:
+
+```python
+# import the necessary charm libs
+from charms.tempo_k8s.v2.tracing import TracingEndpointRequirer, charm_tracing_config
+from charms.tempo_k8s.v1.charm_tracing import charm_tracing
+
+# decorate your charm class with charm_tracing:
+@charm_tracing(
+    # forward-declare the instance attributes that the instrumentor will look up to obtain the
+    # tempo endpoint and server certificate
+    tracing_endpoint="tracing_endpoint",
+    server_cert="server_cert"
+)
+class MyCharm(CharmBase):
+    _path_to_cert = "/path/to/cert.crt"
+    # path to cert file **in the charm container**. Its presence will be used to determine whether
+    # the charm is ready to use tls for encrypting charm traces. If your charm does not support tls,
+    # you can ignore this and pass None to charm_tracing_config.
+    # If you do support TLS, you'll need to make sure that the server cert is copied to this location
+    # and kept up to date so the instrumentor can use it.
+
+    def __init__(self, ...):
+        ...
+        self.tracing = TracingEndpointRequirer(self, ...)
+        self.tracing_endpoint, self.server_cert = charm_tracing_config(self.tracing, self._path_to_cert)
+```
+
+# Detailed usage
+To use this library, you need to do two things:
 1) decorate your charm class with
 
 `@trace_charm(tracing_endpoint="my_tracing_endpoint")`
 
-2) add to your charm a "my_tracing_endpoint" (you can name this attribute whatever you like) **property**
-that returns an otlp http/https endpoint url. If you are using the `TracingEndpointProvider` as
-`self.tracing = TracingEndpointProvider(self)`, the implementation could be:
+2) add to your charm a "my_tracing_endpoint" (you can name this attribute whatever you like)
+**property**, **method** or **instance attribute** that returns an otlp http/https endpoint url.
+If you are using the ``charms.tempo_k8s.v2.tracing.TracingEndpointRequirer`` as
+``self.tracing = TracingEndpointRequirer(self)``, the implementation could be:
 
 ```
     @property
     def my_tracing_endpoint(self) -> Optional[str]:
         '''Tempo endpoint for charm tracing'''
         if self.tracing.is_ready():
-            return self.tracing.otlp_http_endpoint()
+            return self.tracing.get_endpoint("otlp_http")
         else:
             return None
 ```
@@ -33,19 +69,52 @@ At this point your charm will be automatically instrumented so that:
     - every event as a span (including custom events)
     - every charm method call (except dunders) as a span
 
-if you wish to add more fine-grained information to the trace, you can do so by getting a hold of the tracer like so:
+
+## TLS support
+If your charm integrates with a TLS provider which is also trusted by the tracing provider (the Tempo charm),
+you can configure ``charm_tracing`` to use TLS by passing a ``server_cert`` parameter to the decorator.
+
+If your charm is not trusting the same CA as the Tempo endpoint it is sending traces to,
+you'll need to implement a cert-transfer relation to obtain the CA certificate from the same
+CA that Tempo is using.
+
+For example:
+```
+from charms.tempo_k8s.v1.charm_tracing import trace_charm
+@trace_charm(
+    tracing_endpoint="my_tracing_endpoint",
+    server_cert="_server_cert"
+)
+class MyCharm(CharmBase):
+    self._server_cert = "/path/to/server.crt"
+    ...
+
+    def on_tls_changed(self, e) -> Optional[str]:
+        # update the server cert on the charm container for charm tracing
+        Path(self._server_cert).write_text(self.get_server_cert())
+
+    def on_tls_broken(self, e) -> Optional[str]:
+        # remove the server cert so charm_tracing won't try to use tls anymore
+        Path(self._server_cert).unlink()
+```
+
+
+## More fine-grained manual instrumentation
+if you wish to add more spans to the trace, you can do so by getting a hold of the tracer like so:
 ```
 import opentelemetry
 ...
-    @property
-    def tracer(self) -> opentelemetry.trace.Tracer:
-        return opentelemetry.trace.get_tracer(type(self).__name__)
+def get_tracer(self) -> opentelemetry.trace.Tracer:
+    return opentelemetry.trace.get_tracer(type(self).__name__)
 ```
 
 By default, the tracer is named after the charm type. If you wish to override that, you can pass
-a different `service_name` argument to `trace_charm`.
+a different ``service_name`` argument to ``trace_charm``.
 
-*Upgrading from `v0`:*
+See the official opentelemetry Python SDK documentation for usage:
+https://opentelemetry-python.readthedocs.io/en/latest/
+
+## Upgrading from `v0`
 
 If you are upgrading from `charm_tracing` v0, you need to take the following steps (assuming you already
 have the newest version of the library in your charm):
@@ -55,8 +124,9 @@ of `charm_tracing` v0, you can replace it with):
 
 `opentelemetry-exporter-otlp-proto-http>=1.21.0`.
 
-2) Update the charm method referenced to from `@trace` and `@trace_charm`,
-to return from `TracingEndpointRequirer.otlp_http_endpoint()` instead of `grpc_http`. For example:
+2) Update the charm method referenced to from ``@trace`` and ``@trace_charm``,
+to return from ``TracingEndpointRequirer.get_endpoint("otlp_http")`` instead of ``grpc_http``.
+For example:
 
 ```
     from charms.tempo_k8s.v0.charm_tracing import trace_charm
@@ -72,7 +142,7 @@ to return from `TracingEndpointRequirer.otlp_http_endpoint()` instead of `grpc_h
         def my_tracing_endpoint(self) -> Optional[str]:
             '''Tempo endpoint for charm tracing'''
             if self.tracing.is_ready():
-                return self.tracing.otlp_grpc_endpoint()
+                return self.tracing.otlp_grpc_endpoint() #  OLD API, DEPRECATED.
             else:
                 return None
 ```
@@ -93,13 +163,13 @@ needs to be replaced with:
         def my_tracing_endpoint(self) -> Optional[str]:
             '''Tempo endpoint for charm tracing'''
             if self.tracing.is_ready():
-                return self.tracing.otlp_http_endpoint()
+                return self.tracing.get_endpoint("otlp_http")  # NEW API, use this.
             else:
                 return None
 ```
 
-3) If you were passing a certificate using `server_cert`, you need to change it to provide an *absolute* path to
-the certificate file.
+3) If you were passing a certificate (str) using `server_cert`, you need to change it to
+provide an *absolute* path to the certificate file instead.
 """
 
 import functools
@@ -122,6 +192,7 @@ from typing import (
 )
 
 import opentelemetry
+import ops
 from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
 from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace import Span, TracerProvider
@@ -146,14 +217,23 @@ LIBAPI = 1
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
 
-LIBPATCH = 10
+LIBPATCH = 11
 
 PYDEPS = ["opentelemetry-exporter-otlp-proto-http==1.21.0"]
 
 logger = logging.getLogger("tracing")
+dev_logger = logging.getLogger("tracing-dev")
 
+# set this to 0 if you are debugging/developing this library source
+dev_logger.setLevel(logging.CRITICAL)
+
+
+_CharmType = Type[CharmBase]  # the type CharmBase and any subclass thereof
+_C = TypeVar("_C", bound=_CharmType)
+_T = TypeVar("_T", bound=type)
+_F = TypeVar("_F", bound=Type[Callable])
 tracer: ContextVar[Tracer] = ContextVar("tracer")
-_GetterType = Union[Callable[[CharmBase], Optional[str]], property]
+_GetterType = Union[Callable[[_CharmType], Optional[str]], property]
 
 CHARM_TRACING_ENABLED = "CHARM_TRACING_ENABLED"
 
@@ -219,11 +299,6 @@ def _span(name: str) -> Generator[Optional[Span], Any, Any]:
         yield None
 
 
-_C = TypeVar("_C", bound=Type[CharmBase])
-_T = TypeVar("_T", bound=type)
-_F = TypeVar("_F", bound=Type[Callable])
-
-
 class TracingError(RuntimeError):
     """Base class for errors raised by this module."""
 
@@ -232,60 +307,78 @@ class UntraceableObjectError(TracingError):
     """Raised when an object you're attempting to instrument cannot be autoinstrumented."""
 
 
-def _get_tracing_endpoint(tracing_endpoint_getter, self, charm):
-    if isinstance(tracing_endpoint_getter, property):
-        tracing_endpoint = tracing_endpoint_getter.__get__(self)
-    else:  # method or callable
-        tracing_endpoint = tracing_endpoint_getter(self)
+class TLSError(TracingError):
+    """Raised when the tracing endpoint is https but we don't have a cert yet."""
+
+
+def _get_tracing_endpoint(
+    tracing_endpoint_attr: str,
+    charm_instance: object,
+    charm_type: type,
+):
+    _tracing_endpoint = getattr(charm_instance, tracing_endpoint_attr)
+    if callable(_tracing_endpoint):
+        tracing_endpoint = _tracing_endpoint()
+    else:
+        tracing_endpoint = _tracing_endpoint
 
     if tracing_endpoint is None:
-        logger.debug(
-            f"{charm}.{tracing_endpoint_getter} returned None; quietly disabling "
-            f"charm_tracing for the run."
-        )
         return
+
     elif not isinstance(tracing_endpoint, str):
         raise TypeError(
-            f"{charm}.{tracing_endpoint_getter} should return a tempo endpoint (string); "
+            f"{charm_type.__name__}.{tracing_endpoint_attr} should resolve to a tempo endpoint (string); "
             f"got {tracing_endpoint} instead."
         )
-    else:
-        logger.debug(f"Setting up span exporter to endpoint: {tracing_endpoint}/v1/traces")
+
+    dev_logger.debug(f"Setting up span exporter to endpoint: {tracing_endpoint}/v1/traces")
     return f"{tracing_endpoint}/v1/traces"
 
 
-def _get_server_cert(server_cert_getter, self, charm):
-    if isinstance(server_cert_getter, property):
-        server_cert = server_cert_getter.__get__(self)
-    else:  # method or callable
-        server_cert = server_cert_getter(self)
+def _get_server_cert(
+    server_cert_attr: str,
+    charm_instance: ops.CharmBase,
+    charm_type: Type[ops.CharmBase],
+):
+    _server_cert = getattr(charm_instance, server_cert_attr)
+    if callable(_server_cert):
+        server_cert = _server_cert()
+    else:
+        server_cert = _server_cert
 
     if server_cert is None:
         logger.warning(
-            f"{charm}.{server_cert_getter} returned None; sending traces over INSECURE connection."
+            f"{charm_type}.{server_cert_attr} is None; sending traces over INSECURE connection."
         )
         return
     elif not Path(server_cert).is_absolute():
         raise ValueError(
-            f"{charm}.{server_cert_getter} should return a valid tls cert absolute path (string | Path)); "
+            f"{charm_type}.{server_cert_attr} should resolve to a valid tls cert absolute path (string | Path)); "
             f"got {server_cert} instead."
         )
     return server_cert
 
 
 def _setup_root_span_initializer(
-    charm: Type[CharmBase],
-    tracing_endpoint_getter: _GetterType,
-    server_cert_getter: Optional[_GetterType],
+    charm_type: _CharmType,
+    tracing_endpoint_attr: str,
+    server_cert_attr: Optional[str],
     service_name: Optional[str] = None,
 ):
     """Patch the charm's initializer."""
-    original_init = charm.__init__
+    original_init = charm_type.__init__
 
     @functools.wraps(original_init)
     def wrap_init(self: CharmBase, framework: Framework, *args, **kwargs):
+        # we're using 'self' here because this is charm init code, makes sense to read what's below
+        # from the perspective of the charm. Self.unit.name...
+
         original_init(self, framework, *args, **kwargs)
+        # we call this from inside the init context instead of, say, _autoinstrument, because we want it to
+        # be checked on a per-charm-instantiation basis, not on a per-type-declaration one.
         if not is_enabled():
+            # this will only happen during unittesting, hopefully, so it's fine to log a
+            # bit more verbosely
             logger.info("Tracing DISABLED: skipping root span initialization")
             return
 
@@ -311,24 +404,23 @@ def _setup_root_span_initializer(
             }
         )
         provider = TracerProvider(resource=resource)
-        try:
-            tracing_endpoint = _get_tracing_endpoint(tracing_endpoint_getter, self, charm)
-        except Exception:
-            # if anything goes wrong with retrieving the endpoint, we go on with tracing disabled.
-            # better than breaking the charm.
-            logger.exception(
-                f"exception retrieving the tracing "
-                f"endpoint from {charm}.{tracing_endpoint_getter}; "
-                f"proceeding with charm_tracing DISABLED. "
-            )
-            return
+
+        # if anything goes wrong with retrieving the endpoint, we let the exception bubble up.
+        tracing_endpoint = _get_tracing_endpoint(tracing_endpoint_attr, self, charm_type)
 
         if not tracing_endpoint:
+            # tracing is off if tracing_endpoint is None
             return
 
         server_cert: Optional[Union[str, Path]] = (
-            _get_server_cert(server_cert_getter, self, charm) if server_cert_getter else None
+            _get_server_cert(server_cert_attr, self, charm_type) if server_cert_attr else None
         )
+
+        if tracing_endpoint.startswith("https://") and not server_cert:
+            raise TLSError(
+                "Tracing endpoint is https, but no server_cert has been passed."
+                "Please point @trace_charm to a `server_cert` attr."
+            )
 
         exporter = OTLPSpanExporter(
             endpoint=tracing_endpoint,
@@ -361,6 +453,7 @@ def _setup_root_span_initializer(
 
         @contextmanager
         def wrap_event_context(event_name: str):
+            dev_logger.info(f"entering event context: {event_name}")
             # when the framework enters an event context, we create a span.
             with _span("event: " + event_name) as event_context_span:
                 if event_context_span:
@@ -374,6 +467,7 @@ def _setup_root_span_initializer(
 
         @functools.wraps(original_close)
         def wrap_close():
+            dev_logger.info("tearing down tracer and flushing traces")
             span.end()
             opentelemetry.context.detach(span_token)  # type: ignore
             tracer.reset(_tracer_token)
@@ -385,7 +479,7 @@ def _setup_root_span_initializer(
         framework.close = wrap_close
         return
 
-    charm.__init__ = wrap_init
+    charm_type.__init__ = wrap_init  # type: ignore
 
 
 def trace_charm(
@@ -393,7 +487,7 @@ def trace_charm(
     server_cert: Optional[str] = None,
     service_name: Optional[str] = None,
     extra_types: Sequence[type] = (),
-):
+) -> Callable[[_T], _T]:
     """Autoinstrument the decorated charm with tracing telemetry.
 
     Use this function to get out-of-the-box traces for all events emitted on this charm and all
@@ -401,7 +495,7 @@ def trace_charm(
 
     Usage:
     >>> from charms.tempo_k8s.v1.charm_tracing import trace_charm
-    >>> from charms.tempo_k8s.v1.tracing import TracingEndpointProvider
+    >>> from charms.tempo_k8s.v1.tracing import TracingEndpointRequirer
     >>> from ops import CharmBase
     >>>
     >>> @trace_charm(
@@ -411,7 +505,7 @@ def trace_charm(
     >>>
     >>>     def __init__(self, framework: Framework):
     >>>         ...
-    >>>         self.tracing = TracingEndpointProvider(self)
+    >>>         self.tracing = TracingEndpointRequirer(self)
     >>>
     >>>     @property
     >>>     def tempo_otlp_http_endpoint(self) -> Optional[str]:
@@ -420,24 +514,28 @@ def trace_charm(
     >>>         else:
     >>>             return None
     >>>
-    :param server_cert: method or property on the charm type that returns an
-        optional absolute path to a tls certificate to be used when sending traces to a remote server.
-        If it returns None, an _insecure_ connection will be used.
-    :param tracing_endpoint: name of a property on the charm type that returns an
-        optional (fully resolvable) tempo url. If None, tracing will be effectively disabled. Else, traces will be
-        pushed to that endpoint.
+
+    :param tracing_endpoint: name of a method, property or attribute  on the charm type that returns an
+        optional (fully resolvable) tempo url to which the charm traces will be pushed.
+        If None, tracing will be effectively disabled.
+    :param server_cert: name of a method, property or attribute on the charm type that returns an
+        optional absolute path to a CA certificate file to be used when sending traces to a remote server.
+        If it returns None, an _insecure_ connection will be used. To avoid errors in transient
+        situations where the endpoint is already https but there is no certificate on disk yet, it
+        is recommended to disable tracing (by returning None from the tracing_endpoint) altogether
+        until the cert has been written to disk.
     :param service_name: service name tag to attach to all traces generated by this charm.
         Defaults to the juju application name this charm is deployed under.
     :param extra_types: pass any number of types that you also wish to autoinstrument.
         For example, charm libs, relation endpoint wrappers, workload abstractions, ...
     """
 
-    def _decorator(charm_type: Type[CharmBase]):
+    def _decorator(charm_type: _T) -> _T:
         """Autoinstrument the wrapped charmbase type."""
         _autoinstrument(
             charm_type,
-            tracing_endpoint_getter=getattr(charm_type, tracing_endpoint),
-            server_cert_getter=getattr(charm_type, server_cert) if server_cert else None,
+            tracing_endpoint_attr=tracing_endpoint,
+            server_cert_attr=server_cert,
             service_name=service_name,
             extra_types=extra_types,
         )
@@ -447,12 +545,12 @@ def trace_charm(
 
 
 def _autoinstrument(
-    charm_type: Type[CharmBase],
-    tracing_endpoint_getter: _GetterType,
-    server_cert_getter: Optional[_GetterType] = None,
+    charm_type: _T,
+    tracing_endpoint_attr: str,
+    server_cert_attr: Optional[str] = None,
     service_name: Optional[str] = None,
     extra_types: Sequence[type] = (),
-) -> Type[CharmBase]:
+) -> _T:
     """Set up tracing on this charm class.
 
     Use this function to get out-of-the-box traces for all events emitted on this charm and all
@@ -464,29 +562,32 @@ def _autoinstrument(
     >>> from ops.main import main
     >>> _autoinstrument(
     >>>         MyCharm,
-    >>>         tracing_endpoint_getter=MyCharm.tempo_otlp_http_endpoint,
+    >>>         tracing_endpoint_attr="tempo_otlp_http_endpoint",
     >>>         service_name="MyCharm",
     >>>         extra_types=(Foo, Bar)
     >>> )
     >>> main(MyCharm)
 
     :param charm_type: the CharmBase subclass to autoinstrument.
-    :param server_cert_getter: method or property on the charm type that returns an
-        optional absolute path to a tls certificate to be used when sending traces to a remote server.
-        This needs to be a valid path to a certificate.
-    :param tracing_endpoint_getter: method or property on the charm type that returns an
-        optional tempo url. If None, tracing will be effectively disabled. Else, traces will be
-        pushed to that endpoint.
+    :param tracing_endpoint_attr: name of a method, property or attribute  on the charm type that returns an
+        optional (fully resolvable) tempo url to which the charm traces will be pushed.
+        If None, tracing will be effectively disabled.
+    :param server_cert_attr: name of a method, property or attribute on the charm type that returns an
+        optional absolute path to a CA certificate file to be used when sending traces to a remote server.
+        If it returns None, an _insecure_ connection will be used. To avoid errors in transient
+        situations where the endpoint is already https but there is no certificate on disk yet, it
+        is recommended to disable tracing (by returning None from the tracing_endpoint) altogether
+        until the cert has been written to disk.
     :param service_name: service name tag to attach to all traces generated by this charm.
         Defaults to the juju application name this charm is deployed under.
     :param extra_types: pass any number of types that you also wish to autoinstrument.
         For example, charm libs, relation endpoint wrappers, workload abstractions, ...
     """
-    logger.info(f"instrumenting {charm_type}")
+    dev_logger.info(f"instrumenting {charm_type}")
     _setup_root_span_initializer(
         charm_type,
-        tracing_endpoint_getter,
-        server_cert_getter=server_cert_getter,
+        tracing_endpoint_attr,
+        server_cert_attr=server_cert_attr,
         service_name=service_name,
     )
     trace_type(charm_type)
@@ -503,12 +604,12 @@ def trace_type(cls: _T) -> _T:
     It assumes that this class is only instantiated after a charm type decorated with `@trace_charm`
     has been instantiated.
     """
-    logger.info(f"instrumenting {cls}")
+    dev_logger.info(f"instrumenting {cls}")
     for name, method in inspect.getmembers(cls, predicate=inspect.isfunction):
-        logger.info(f"discovered {method}")
+        dev_logger.info(f"discovered {method}")
 
         if method.__name__.startswith("__"):
-            logger.info(f"skipping {method} (dunder)")
+            dev_logger.info(f"skipping {method} (dunder)")
             continue
 
         new_method = trace_method(method)
@@ -536,7 +637,7 @@ def trace_function(function: _F) -> _F:
 
 
 def _trace_callable(callable: _F, qualifier: str) -> _F:
-    logger.info(f"instrumenting {callable}")
+    dev_logger.info(f"instrumenting {callable}")
 
     # sig = inspect.signature(callable)
     @functools.wraps(callable)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,8 @@ target-version = ["py38"]
 [tool.ruff]
 line-length = 99
 extend-exclude = ["__pycache__", "*.egg_info"]
+
+[tool.ruff.lint]
 select = ["E", "W", "F", "C", "N", "R", "D", "I001"]
 # Ignore E501 because using black creates errors with this
 # Ignore D107 Missing docstring in __init__
@@ -24,7 +26,8 @@ ignore = ["E501", "D107", "N818", "RET504"]
 # D100, D101, D102, D103: Ignore missing docstrings in tests
 per-file-ignores = {"tests/*" = ["D100","D101","D102","D103"]}
 
-[tool.ruff.pydocstyle]
+
+[tool.ruff.lint.pydocstyle]
 convention = "google"
 
 # Static analysis tools configuration

--- a/src/charm.py
+++ b/src/charm.py
@@ -126,6 +126,7 @@ class AlertmanagerCharm(CharmBase):
             refresh_event=[
                 self.ingress.on.ready,
                 self.ingress.on.revoked,
+                self.on.update_status,
                 self.server_cert.on.cert_changed,
             ],
         )

--- a/src/charm.py
+++ b/src/charm.py
@@ -123,6 +123,11 @@ class AlertmanagerCharm(CharmBase):
             charm=self,
             source_type="alertmanager",
             source_url=self._external_url,
+            refresh_event=[
+                self.ingress.on.ready,
+                self.ingress.on.revoked,
+                self.server_cert.on.cert_changed,
+            ],
         )
         self.karma_provider = KarmaProvider(self, "karma-dashboard")
         self.remote_configuration = RemoteConfigurationRequirer(self)

--- a/tox.ini
+++ b/tox.ini
@@ -34,7 +34,7 @@ deps =
     black
     ruff
 commands =
-    ruff --fix {[vars]all_path}
+    ruff check --fix {[vars]all_path}
     black {[vars]all_path}
 
 [testenv:lint]
@@ -46,7 +46,7 @@ deps =
 commands =
     codespell {[vars]lib_path}
     codespell . --skip .git --skip .tox --skip build --skip lib --skip venv --skip .mypy_cache
-    ruff {[vars]all_path}
+    ruff check {[vars]all_path}
     black --check --diff {[vars]all_path}
 
 [testenv:static-{charm,lib}]


### PR DESCRIPTION
## Issue
Closes #224. Alertmanager is already using `external_url` in the Grafana Source integration. However, no refresh event is passed to `GrafanaSourceProvider`, meaning it won't start using the `external_url` if it doesn't have a traefik integration from the very start (e.g., when deployed from the bundle).


## Solution
Pass extra refresh events so the Grafana Source URL is updated correctly.

## Extra

`charmcraft fetch-lib`


## Additional Context
https://github.com/canonical/observability/blob/main/decision-records/2024-07-16--shared-urls.md