### PR TITLE
fix: add rust compiler for building charm dependencies

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -11,4 +11,8 @@ bases:
       channel: "20.04"
 parts:
   charm:
+    build-packages:
+      # rustc and cargo required to build tracing lib's dependency pydantic
+      - rustc
+      - cargo
     charm-binary-python-packages: [ops, PyYAML, cryptography, jsonschema]


### PR DESCRIPTION

## Issue
fixes error in charmcraft file of "error: can't find Rust compiler", caused when building tracing library's pydanic dependency


## Solution
Add rustc and cargo to the charm build-packages


## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
If this charm packs successfully and passes integration tests, the fix worked

## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->
