### PR TITLE
observe on.start event to make start up process more robust

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -165,6 +165,7 @@ class AlertmanagerCharm(CharmBase):
 
         # Core lifecycle events
         self.framework.observe(self.on.config_changed, self._on_config_changed)
+        self.framework.observe(self.on.start, self._on_start)
 
         peer_ha_netlocs = [
             f"{hostname}:{self._ports.ha}"
@@ -484,6 +485,10 @@ class AlertmanagerCharm(CharmBase):
         self._common_exit_hook()
 
     def _on_config_changed(self, _):
+        """Event handler for ConfigChangedEvent."""
+        self._common_exit_hook(update_ca_certs=True)
+
+    def _on_start(self, _):
         """Event handler for ConfigChangedEvent."""
         self._common_exit_hook(update_ca_certs=True)
 

--- a/tests/scenario/conftest.py
+++ b/tests/scenario/conftest.py
@@ -23,6 +23,8 @@ def alertmanager_charm():
         is_ready=tautology,
     ), patch.object(WorkloadManager, "check_config", lambda *a, **kw: ("ok", "")), patch.object(
         WorkloadManager, "_alertmanager_version", property(lambda *_: "0.0.0")
+    ), patch(
+        "subprocess.run"
     ):
         yield AlertmanagerCharm
 

--- a/tests/scenario/helpers.py
+++ b/tests/scenario/helpers.py
@@ -1,11 +1,20 @@
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-from scenario import Container, Context, PeerRelation, Relation, State
+from scenario import Container, Context, ExecOutput, PeerRelation, Relation, State
 
 
 def begin_with_initial_hooks_isolated(context: Context, *, leader: bool = True) -> State:
-    container = Container("alertmanager", can_connect=False)
+    container = Container(
+        "alertmanager",
+        can_connect=False,
+        exec_mock={
+            ("update-ca-certificates", "--fresh"): ExecOutput(  # this is the command we're mocking
+                return_code=0,  # this data structure contains all we need to mock the call.
+                stdout="OK",
+            )
+        },
+    )
     state = State(config={"config_file": ""}, containers=[container])
     peer_rel = PeerRelation("replicas")
 

--- a/tox.ini
+++ b/tox.ini
@@ -100,7 +100,7 @@ commands =
 description = Scenario tests
 deps =
     pytest
-    ops-scenario>=6
+    ops-scenario<7
     cosl
     -r{toxinidir}/requirements.txt
 commands =


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->

The idea of this small PR is to make start up process more robust and avoid to go through intermediate unnecessary `error` states.

We just explicitly observe `on.start` event. 

Issue related: #282



## Testing Instructions
<!-- What steps need to be taken to test this PR? -->

Just run tests
