### PR TITLE
Support specifying the number of units to run as a Terraform input

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -20,6 +20,7 @@ The module offers the following configurable inputs:
 | `constraints` | string | Constraints to be applied | "" |
 | `model_name` | string | Name of the model that the charm is deployed on | ""  |
 | `revision` | number | Charm revision | null |
+| `units` | number | Number of units to run | 1 |
 
 
 ### Outputs

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -8,4 +8,5 @@ resource "juju_application" "alertmanager" {
     revision = var.revision
   }
   config = var.config
+  units  = var.units
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -35,3 +35,9 @@ variable "revision" {
   nullable    = true
   default     = null
 }
+
+variable "units" {
+  description = "Number of units to run"
+  type        = number
+  default     = 1
+}


### PR DESCRIPTION
## Issue
Adds support for specifying the number of units to run as a Terraform input, closes #332 .


## Solution
Adds support for specifying the number of units to run as a Terraform input, following the pattern other Terraform inputs use in this module.

The `Check libraries` CI check is failing because my fork of this repository does not have the required access.


## Context
N/A

## Testing Instructions
1. Deploy Alertmanager locally using Terraform
2. Change the `units` input value to a number higher than one
3. Check that the Alertmanager charm deployment now runs with the specified number of units


## Upgrade Notes
N/A
