### PR TITLE
refactor: update service mesh lib and policy objects

### DIFF
--- a/lib/charms/istio_beacon_k8s/v0/service_mesh.py
+++ b/lib/charms/istio_beacon_k8s/v0/service_mesh.py
@@ -50,7 +50,7 @@ provides:
 Instantiate a ServiceMeshConsumer object in your charm's `__init__` method:
 
 ```python
-from charms.istio_beacon_k8s.v0.service_mesh import Method, Endpoint, Policy, ServiceMeshConsumer
+from charms.istio_beacon_k8s.v0.service_mesh import Method, Endpoint, AppPolicy, UnitPolicy, ServiceMeshConsumer
 
 class MyCharm(CharmBase):
     def __init__(self, *args):
@@ -58,17 +58,7 @@ class MyCharm(CharmBase):
         self._mesh = ServiceMeshConsumer(
             self,
             policies=[
-                Policy(
-                    relation="metrics",
-                    endpoints=[
-                        Endpoint(
-                            ports=[HTTP_LISTEN_PORT],
-                            methods=[Method.get],
-                            paths=["/metrics"],
-                        ),
-                    ],
-                ),
-                Policy(
+                AppPolicy(
                     relation="data",
                     endpoints=[
                         Endpoint(
@@ -78,13 +68,20 @@ class MyCharm(CharmBase):
                         ),
                     ],
                 ),
+                UnitPolicy(
+                    relation="metrics",
+                    ports=[HTTP_LISTEN_PORT],
+                ),
             ],
         )
 ```
 
 This example creates two policies:
-- When related over the `metrics` relation allow the related application to `GET` this application's `/metrics` endpoint on the specified port
-- When related over the `data` relation allow the relation application to `GET` this application's `/data` endpoint on the specified port
+- An app policy - When related over the `data` relation, allow the related application to `GET` this application's `/data` endpoint on the specified port through the app's Kubernetes service.
+- A unit policy - When related over the `metrics` relation, allow the related application to access this application's unit pods directly on the specified port without any other restriction. UnitPolicy does not support fine-grained access control on the methods and paths via `Endpoints`.
+
+An AppPolicy can be used to control how the source application can communicate with the target application via the app address.
+A UnitPolicy allows access to the specified port but only to the unit pods of the charm via individual unit addresses.
 
 ### Cross-Model Relations
 To request service mesh policies for cross-model relations, additional information is required.
@@ -139,7 +136,8 @@ for policy in self._mesh.mesh_info():
 
 - **Method**: Defines enum for HTTP methods (GET, POST, PUT, etc.)
 - **Endpoint**: Defines traffic endpoints with hosts, ports, methods, and paths
-- **Policy**: Defines authorization policy for the consumer
+- **AppPolicy**: Defines application level authorization policy for the consumer
+- **UnitPolicy**: Defines unit level authorization policy for the consumer
 - **MeshPolicy**: Contains complete policy information for mesh configuration
 - **CMRData**: Contains cross-model relation metadata
 """
@@ -147,7 +145,8 @@ for policy in self._mesh.mesh_info():
 import enum
 import json
 import logging
-from typing import Dict, List, Optional
+import warnings
+from typing import Dict, List, Literal, Optional, Union
 
 import httpx
 import pydantic
@@ -159,7 +158,7 @@ from ops import CharmBase, Object, RelationMapping
 
 LIBID = "3f40cb7e3569454a92ac2541c5ca0a0c"  # Never change this
 LIBAPI = 0
-LIBPATCH = 6
+LIBPATCH = 7
 
 PYDEPS = ["lightkube", "pydantic"]
 
@@ -193,12 +192,47 @@ class Endpoint(pydantic.BaseModel):
     paths: Optional[List[str]] = None
 
 
+class PolicyTargetType(str, enum.Enum):
+    """Target type for Policy classes."""
+
+    app = "app"
+    unit = "unit"
+
+
 class Policy(pydantic.BaseModel):
     """Data type for defining a policy for your charm."""
 
     relation: str
     endpoints: List[Endpoint]
     service: Optional[str] = None
+
+    def __init__(self, **data):
+        warnings.warn(
+            "Polcy is deprecated. Use AppPolicy for fine-grained application-level policies "
+            "or UnitPolicy to allow access to charm units. For migration, Policy can be "
+            "directly replaced with AppPolicy.",
+            DeprecationWarning,
+            stacklevel=2
+        )
+        super().__init__(**data)
+
+
+class AppPolicy(pydantic.BaseModel):
+    """Data type for defining a policy for your charm application."""
+
+    relation: str
+    endpoints: List[Endpoint]
+    service: Optional[str] = None
+
+
+class UnitPolicy(pydantic.BaseModel):
+    """Data type for defining a policy for your charm unit."""
+
+    relation: str
+    # UnitPolicy at the moment only supports access control over ports.
+    # This limitation stems from the currenlty supported upstream service meshes (Istio).
+    # Since other attributes of Endpoints class are not supported, the easiest implementation was to use just the ports attribute in this class.
+    ports: Optional[List[int]] = None
 
 
 class MeshPolicy(pydantic.BaseModel):
@@ -209,6 +243,7 @@ class MeshPolicy(pydantic.BaseModel):
     target_app_name: str
     target_namespace: str
     target_service: Optional[str] = None
+    target_type: Literal[PolicyTargetType.app, PolicyTargetType.unit] = PolicyTargetType.app
     endpoints: List[Endpoint]
 
 
@@ -228,7 +263,7 @@ class ServiceMeshConsumer(Object):
         mesh_relation_name: str = "service-mesh",
         cross_model_mesh_requires_name: str = "require-cmr-mesh",
         cross_model_mesh_provides_name: str = "provide-cmr-mesh",
-        policies: Optional[List[Policy]] = None,
+        policies: Optional[List[Union[Policy, AppPolicy, UnitPolicy]]] = None,
         auto_join: bool = True,
     ):
         """Class used for joining a service mesh.
@@ -412,7 +447,7 @@ def build_mesh_policies(
         relation_mapping: RelationMapping,
         target_app_name: str,
         target_namespace: str,
-        policies: List[Policy],
+        policies: List[Union[Policy, AppPolicy, UnitPolicy]],
         cmr_application_data: Dict[str, CMRData]
 ) -> List[MeshPolicy]:
     """Generate MeshPolicy that implement the given policies for the currently related applications.
@@ -421,7 +456,7 @@ def build_mesh_policies(
         relation_mapping: Charm's RelatioMapping object, for example self.model.relations.
         target_app_name: The name of the target application, for example self.app.name.
         target_namespace: The namespace of the target application, for example self.model.name.
-        policies: List of Policy objects defining the access rules.
+        policies: List of AppPolicy, or UnitPolicy objects defining the access rules.
         cmr_application_data: Data for cross-model relations, mapping app names to CMRData.
     """
     mesh_policies = []
@@ -436,16 +471,36 @@ def build_mesh_policies(
                 source_app_name = relation.app.name
                 source_namespace = target_namespace
 
-            mesh_policies.append(
-                MeshPolicy(
-                    source_app_name=source_app_name,
-                    source_namespace=source_namespace,
-                    target_app_name=target_app_name,
-                    target_namespace=target_namespace,
-                    target_service=policy.service,
-                    endpoints=policy.endpoints,
-                ).model_dump()
-            )
+            if isinstance(policy, UnitPolicy):
+                mesh_policies.append(
+                    MeshPolicy(
+                        source_app_name=source_app_name,
+                        source_namespace=source_namespace,
+                        target_app_name=target_app_name,
+                        target_namespace=target_namespace,
+                        target_service=None,
+                        target_type=PolicyTargetType.unit,
+                        endpoints=[
+                            Endpoint(
+                                ports=policy.ports,
+                            )
+                        ]
+                        if policy.ports
+                        else [],
+                    ).model_dump()
+                )
+            else:
+               mesh_policies.append(
+                    MeshPolicy(
+                        source_app_name=source_app_name,
+                        source_namespace=source_namespace,
+                        target_app_name=target_app_name,
+                        target_namespace=target_namespace,
+                        target_service=policy.service,
+                        target_type=PolicyTargetType.app,
+                        endpoints=policy.endpoints,
+                    ).model_dump()
+                )
     return mesh_policies
 
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -21,7 +21,7 @@ from charms.alertmanager_k8s.v1.alertmanager_dispatch import AlertmanagerProvide
 from charms.catalogue_k8s.v1.catalogue import CatalogueConsumer, CatalogueItem
 from charms.grafana_k8s.v0.grafana_dashboard import GrafanaDashboardProvider
 from charms.grafana_k8s.v0.grafana_source import GrafanaSourceProvider
-from charms.istio_beacon_k8s.v0.service_mesh import Endpoint, Method, Policy, ServiceMeshConsumer
+from charms.istio_beacon_k8s.v0.service_mesh import ServiceMeshConsumer, UnitPolicy
 from charms.karma_k8s.v0.karma_dashboard import KarmaProvider
 from charms.observability_libs.v0.kubernetes_compute_resources_patch import (
     K8sResourcePatchFailedEvent,
@@ -190,34 +190,18 @@ class AlertmanagerCharm(CharmBase):
         self._mesh = ServiceMeshConsumer(
             self,
             policies=[
-                Policy(
-                    relation="self-metrics-endpoint",
-                    endpoints=[
-                        Endpoint(
-                            ports=[self.api_port],
-                            methods=[Method.get],
-                            paths=["/metrics"],
-                        ),
-                    ],
-                ),
-                Policy(
+                UnitPolicy(
                     relation="alerting",
-                    endpoints=[
-                        Endpoint(
-                            ports=[self.api_port],
-                            methods=[Method.post],
-                        )
-                    ]
+                    ports=[self.api_port],
                 ),
-                Policy(
+                UnitPolicy(
                     relation="grafana-source",
-                    endpoints=[
-                        Endpoint(
-                            ports=[self.api_port],
-                            methods=[Method.get],
-                        )
-                    ]
-                )
+                    ports=[self.api_port],
+                ),
+                UnitPolicy(
+                    relation="self-metrics-endpoint",
+                    ports=[self.api_port],
+                ),
             ],
         )
 


### PR DESCRIPTION
## Issue
The service mesh library was updated to handle access controls to the units and the charm application differently. 

This PR updates the service_mesh library to the latest version and correspondingly changes the implementation of authorization policies in the alertmanager charm code.

For more details on adding authorization policy to a charm and what `UnitPolicy` does, please refer to this [Canonical Service Mesh](https://canonical-service-mesh-documentation.readthedocs-hosted.com/en/latest/how-to/add-mesh-support-to-your-charm/#enable-automatic-fine-grained-access-to-other-charmed-applications-via-policies) documentation
