### PR TITLE
ci: provide a remote unit when departing

### DIFF
--- a/tests/unit/test_brute_isolated.py
+++ b/tests/unit/test_brute_isolated.py
@@ -15,7 +15,7 @@ def test_startup_shutdown_sequence(context: Context):
     state = context.run(context.on.update_status(), state)
 
     for peer_rel in state.get_relations("replicas"):
-        state = context.run(context.on.relation_departed(peer_rel), state)
+        state = context.run(context.on.relation_departed(peer_rel, remote_unit=2), state)
 
     state = context.run(context.on.stop(), state)
     context.run(context.on.remove(), state)


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->

When Juju emits a relation-departed event, there is always a `REMOTE_UNIT` set. However, this is not currently the case for one of the tests.

## Solution
<!-- A summary of the solution addressing the above issue -->

Set the remote unit to an arbitrary unit ID (2) in the test.

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->

In a future version of ops[testing], there will be a new consistency check for this case, to ensure that the event context is closer to the real context that Juju would provide. The test currently passes because ops[testing] (Scenario) lets it slide that one isn't there, but won't in that future version.

## Testing Instructions
<!-- What steps need to be taken to test this PR? -->

Run the tests (or even just the specific test that's changing).

## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->

N/A