### PR TITLE
chore: add api endpoints and docs to catalogue item

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -280,6 +280,10 @@ class AlertmanagerCharm(CharmBase):
 
     @property
     def _catalogue_item(self) -> CatalogueItem:
+        api_endpoints = {
+            "Alerts": "/api/v2/alerts"
+        }
+
         return CatalogueItem(
             name="Alertmanager",
             icon="bell-alert",
@@ -289,6 +293,8 @@ class AlertmanagerCharm(CharmBase):
                 "Prometheus or Loki, then deduplicates, groups and routes them to "
                 "the configured receiver(s)."
             ),
+            api_docs="https://github.com/prometheus/alertmanager/blob/main/api/v2/openapi.yaml",
+            api_endpoints={key: f"{self._external_url}{path}" for key, path in api_endpoints.items()},
         )
 
     @property


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
A [recent PR in Catalogue](https://github.com/canonical/catalogue-k8s-operator/pull/184) added functionality to the Catalogue library for Catalogue Items to provide links to their API docs and API endpoints. We need to add these fields when Mimir creates its Catalogue Items.

In tandem with PRs in:
- [Prometheus](https://github.com/canonical/prometheus-k8s-operator/pull/726)
- [Loki Coordinator](https://github.com/canonical/loki-coordinator-k8s-operator/pull/88)
- [Grafana](https://github.com/canonical/grafana-k8s-operator/pull/451)

## Solution
<!-- A summary of the solution addressing the above issue -->
This PR links to the upstream [HTTP API docs for Alertmanager](https://github.com/prometheus/alertmanager/blob/main/api/v2/openapi.yaml). It also lists some of the more commonly accessed ones to the list of API endpoints. 
The added endpoints are:
```python
api_endpoints = {
            "Alerts": "/api/v2/alerts"
        }
```

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->


## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->
