### PR TITLE
ci: add explicit workflow permissions for CodeQL

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -6,6 +6,13 @@ on:
       - main
       - track/**
 
+permissions:
+  # Required for CodeQL security scanning
+  security-events: write
+  # Required for private repositories
+  actions: read
+  contents: read
+
 jobs:
   pull-request:
     name: PR

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,6 +6,13 @@ on:
       - main
       - track/**
 
+permissions:
+  # Required for CodeQL security scanning
+  security-events: write
+  # Required for private repositories
+  actions: read
+  contents: read
+
 jobs:
   release:
     uses: canonical/observability/.github/workflows/charm-release.yaml@v2


### PR DESCRIPTION
Add explicit permissions block to workflows calling central CI from canonical/observability.

Required due to org-level GitHub Actions permission changes (default changed from read-write to read). The CodeQL analysis in the reusable workflow requires security-events: write permission.