### PR TITLE
ci: fix token permissions for release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,7 +11,8 @@ permissions:
   security-events: write
   # Required for private repositories
   actions: read
-  contents: read
+  # Write permission needed for the reusable workflow to push git tags
+  contents: write
 
 jobs:
   release:


### PR DESCRIPTION
## Summary

The recent CodeQL permissions PR set `contents: read` in the release workflow, but the reusable workflow from `canonical/observability` needs `contents: write` to push git tags during charm releases.

This fixes the error:
```
remote: Permission to <repo>.git denied to github-actions[bot].
fatal: unable to access 'https://github.com/<repo>.git/': The requested URL returned error: 403
```

## Changes

- Changed `contents: read` to `contents: write` in `.github/workflows/release.yaml`
- Added comment explaining why write permission is needed