### PR TITLE
docs: update show-config Juju command

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ To verify Alertmanager is using the expected configuration you can use the
 [`show-config`](https://charmhub.io/alertmanager-k8s/actions#show-config) action:
 
 ```shell
-juju run-action alertmanager-k8s/0 show-config --wait
+juju run alertmanager-k8s/0 show-config
 ```
 
 


### PR DESCRIPTION
Closes #429

## Summary
- update the README show-config example from the removed Juju run-action syntax to the Juju 3.x juju run syntax
- keep the example scoped to the existing show-config action

## Checks
- git diff --check
- rg -n "run-action|juju run alertmanager-k8s/0 show-config|show-config" README.md charmcraft.yaml src/charm.py
