### PR TITLE
feat: loosely AlertmanagerPagerdutyNotificationsFailing 

### DIFF
--- a/src/prometheus_alert_rules/alertmanager_notifications_failed.rule
+++ b/src/prometheus_alert_rules/alertmanager_notifications_failed.rule
@@ -2,7 +2,7 @@ groups:
 - name: AlertmanagerNotificationsFailed
   rules:
   - alert: AlertmanagerNotificationsFailed
-    expr: rate(alertmanager_notifications_failed_total{integration=~".*"}[5m]) > 0
+    expr: rate(alertmanager_notifications_failed_total{integration=~".*"}[5m]) > 0.02
     for: 0m
     labels:
       severity: warning

--- a/src/prometheus_alert_rules/alertmanager_notifications_failed.rule
+++ b/src/prometheus_alert_rules/alertmanager_notifications_failed.rule
@@ -2,8 +2,8 @@ groups:
 - name: AlertmanagerNotificationsFailed
   rules:
   - alert: AlertmanagerNotificationsFailed
-    expr: rate(alertmanager_notifications_failed_total{integration=~".*"}[5m]) > 0.02
-    for: 0m
+    expr: increase(alertmanager_notifications_failed_total[5m]) > 5
+    for: 10m
     labels:
       severity: warning
     annotations:


### PR DESCRIPTION
The current alert expression:

```promql
rate(alertmanager_notifications_failed_total{integration=".*"}[5m]) > 0
```

Is the noisiest alert in the stack. Any single failed notification attempt — including transient TCP connection rejections — triggers it. This causes near-constant firing that desensitizes on-call engineers and reduces trust in the alert.

The proposed change is:
```promql
expr: increase(alertmanager_notifications_failed_total[5m]) > 5
```


Meaning: If more than 5 Alertmanager notification delivery failures (across any integration) occur within a trailing 5-minute window, and that condition holds continuously for 10 minutes, fire a warning alert.
