### PR TITLE
fix: constant service restarts

### DIFF
--- a/src/alertmanager.py
+++ b/src/alertmanager.py
@@ -15,6 +15,7 @@ from ops.pebble import (  # type: ignore
     ChangeError,
     ExecError,
     Layer,
+    PathError,
 )
 
 from alertmanager_client import Alertmanager, AlertmanagerBadResponse
@@ -52,6 +53,24 @@ class ConfigFileSystemState:
             else:
                 container.push(filepath, content, make_dirs=True)
 
+    def has_changes(self, container: Container) -> bool:
+        """Return True if any file in the manifest differs from what's in the container."""
+        for filepath, content in self._manifest.items():
+            try:
+                existing = container.pull(filepath).read()
+            except PathError:
+                existing = None
+
+            if content is None:
+                # File should be removed; check if it still exists.
+                if existing is not None:
+                    return True
+            else:
+                # File should exist with given content; check if it differs.
+                if existing != content:
+                    return True
+        return False
+
 
 class WorkloadManagerError(Exception):
     """Base class for exceptions raised by WorkloadManager."""
@@ -84,6 +103,7 @@ class WorkloadManager(Object):
         api_port: int,
         ha_port: int,
         web_external_url: str,
+        web_internal_url: str,
         web_route_prefix: str,
         config_path: str,
         web_config_path: str,
@@ -102,7 +122,7 @@ class WorkloadManager(Object):
 
         self._api_port = api_port
         self._ha_port = ha_port
-        self.api = Alertmanager(endpoint_url=web_external_url, cafile=cafile)
+        self.api = Alertmanager(endpoint_url=web_internal_url, cafile=cafile)
         self._web_external_url = web_external_url
         self._web_route_prefix = web_route_prefix
         self._config_path = config_path
@@ -244,17 +264,21 @@ class WorkloadManager(Object):
                 str(e),
             )
 
-    def update_config(self, manifest: ConfigFileSystemState) -> None:
+    def update_config(self, manifest: ConfigFileSystemState) -> bool:
         """Update alertmanager config files to reflect changes in configuration.
 
-        After pushing a new config, a hot-reload is attempted. If hot-reload fails, the service is
-        restarted.
+        Returns:
+            True if any config file was changed; False otherwise.
 
         Raises:
           ConfigUpdateFailure, if failed to update configuration file.
         """
         if not self.is_ready:
             raise ContainerNotReady("cannot update config")
+
+        if not manifest.has_changes(self._container):
+            logger.debug("no config changes to apply")
+            return False
 
         logger.debug("applying config changes")
         manifest.apply(self._container)
@@ -264,6 +288,8 @@ class WorkloadManager(Object):
             self.check_config()
         except WorkloadManagerError as e:
             raise ConfigUpdateFailure("Failed to validate config (run check-config action)") from e
+
+        return True
 
     def restart_service(self) -> bool:
         """Helper function for restarting the underlying service.

--- a/src/charm.py
+++ b/src/charm.py
@@ -221,6 +221,7 @@ class AlertmanagerCharm(CharmBase):
             api_port=self.api_port,
             ha_port=self._ports.ha,
             web_external_url=self._external_url,
+            web_internal_url=self._internal_url,
             web_route_prefix="/",
             config_path=self._config_path,
             web_config_path=self._web_config_path,
@@ -510,7 +511,7 @@ class AlertmanagerCharm(CharmBase):
 
         # Update config file
         try:
-            self.alertmanager_workload.update_config(self._render_manifest())
+            config_changed = self.alertmanager_workload.update_config(self._render_manifest())
         except (ConfigUpdateFailure, ConfigError) as e:
             self.unit.status = BlockedStatus(str(e))
             return
@@ -518,12 +519,13 @@ class AlertmanagerCharm(CharmBase):
         # Update pebble layer
         self.alertmanager_workload.update_layer()
 
-        # Reload or restart the service
-        try:
-            self.alertmanager_workload.reload()
-        except ConfigUpdateFailure as e:
-            self.unit.status = BlockedStatus(str(e))
-            return
+        # Reload or restart the service only if config changed
+        if config_changed:
+            try:
+                self.alertmanager_workload.reload()
+            except ConfigUpdateFailure as e:
+                self.unit.status = BlockedStatus(str(e))
+                return
 
         self.catalog.update_item(item=self._catalogue_item)
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -462,6 +462,30 @@ class AlertmanagerCharm(CharmBase):
             }
         )
 
+    def _update_workload_config(self) -> bool:
+        """Update alertmanager config and reload if changed.
+
+        Returns True if the charm should continue (no blockers), False if blocked.
+        """
+        try:
+            config_changed = self.alertmanager_workload.update_config(self._render_manifest())
+        except (ConfigUpdateFailure, ConfigError) as e:
+            self.unit.status = BlockedStatus(str(e))
+            return False
+
+        # Update pebble layer
+        self.alertmanager_workload.update_layer()
+
+        # Reload or restart the service only if config changed
+        if config_changed:
+            try:
+                self.alertmanager_workload.reload()
+            except ConfigUpdateFailure as e:
+                self.unit.status = BlockedStatus(str(e))
+                return False
+
+        return True
+
     def _common_exit_hook(self, update_ca_certs: bool = False) -> None:
         """Event processing hook that is common to all events to ensure idempotency."""
         if not self.resources_patch.is_ready():
@@ -510,22 +534,8 @@ class AlertmanagerCharm(CharmBase):
         self.karma_provider.target = self._external_url
 
         # Update config file
-        try:
-            config_changed = self.alertmanager_workload.update_config(self._render_manifest())
-        except (ConfigUpdateFailure, ConfigError) as e:
-            self.unit.status = BlockedStatus(str(e))
+        if not self._update_workload_config():
             return
-
-        # Update pebble layer
-        self.alertmanager_workload.update_layer()
-
-        # Reload or restart the service only if config changed
-        if config_changed:
-            try:
-                self.alertmanager_workload.reload()
-            except ConfigUpdateFailure as e:
-                self.unit.status = BlockedStatus(str(e))
-                return
 
         self.catalog.update_item(item=self._catalogue_item)
 

--- a/src/config_builder.py
+++ b/src/config_builder.py
@@ -104,8 +104,8 @@ class ConfigBuilder:
         # The special value '...' disables aggregation entirely. Do not add topology in that case.
         # Ref: https://prometheus.io/docs/alerting/latest/configuration/#route
         if group_by != {"..."}:
-            group_by = list(group_by.union(["juju_application", "juju_model", "juju_model_uuid"]))
-        route["group_by"] = list(group_by)
+            group_by = group_by.union(["juju_application", "juju_model", "juju_model_uuid"])
+        route["group_by"] = sorted(group_by)
         config["route"] = route
         return yaml.safe_dump(config)
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,3 +1,4 @@
+from contextlib import ExitStack
 from unittest.mock import patch
 
 import pytest
@@ -29,20 +30,26 @@ def tautology(*_, **__) -> bool:
 
 @pytest.fixture(autouse=True)
 def alertmanager_charm():
-    with patch("lightkube.core.client.GenericSyncClient"), patch.multiple(
-        "charm.KubernetesComputeResourcesPatch",
-        _namespace="test-namespace",
-        _patch=tautology,
-        is_ready=tautology,
-    ), patch.object(WorkloadManager, "check_config", lambda *a, **kw: ("ok", "")), patch.object(
-        WorkloadManager, "reload", lambda *a, **kw: None
-    ), patch(
-        "alertmanager.Alertmanager.config", lambda *a, **kw: {}
-    ), patch(
-        "alertmanager.Alertmanager.status", lambda *a, **kw: {}
-    ), patch.object(
-        WorkloadManager, "_alertmanager_version", property(lambda *_: "0.0.0")
-    ), patch("subprocess.run"):
+    with ExitStack() as stack:
+        stack.enter_context(patch("lightkube.core.client.GenericSyncClient"))
+        stack.enter_context(
+            patch.multiple(
+                "charm.KubernetesComputeResourcesPatch",
+                _namespace="test-namespace",
+                _patch=tautology,
+                is_ready=tautology,
+            )
+        )
+        stack.enter_context(
+            patch.object(WorkloadManager, "check_config", lambda *a, **kw: ("ok", ""))
+        )
+        stack.enter_context(patch.object(WorkloadManager, "reload", lambda *a, **kw: None))
+        stack.enter_context(
+            patch.object(
+                WorkloadManager, "_alertmanager_version", property(lambda *_: "0.0.0")
+            )
+        )
+        stack.enter_context(patch("subprocess.run"))
         yield AlertmanagerCharm
 
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -4,7 +4,7 @@ import pytest
 from charms.tempo_coordinator_k8s.v0.charm_tracing import charm_tracing_disabled
 from ops.testing import Context
 
-from src.alertmanager import WorkloadManager
+from alertmanager import Alertmanager, WorkloadManager
 from src.charm import AlertmanagerCharm
 
 
@@ -35,6 +35,12 @@ def alertmanager_charm():
         _patch=tautology,
         is_ready=tautology,
     ), patch.object(WorkloadManager, "check_config", lambda *a, **kw: ("ok", "")), patch.object(
+        WorkloadManager, "reload", lambda *a, **kw: None
+    ), patch(
+        "alertmanager.Alertmanager.config", lambda *a, **kw: {}
+    ), patch(
+        "alertmanager.Alertmanager.status", lambda *a, **kw: {}
+    ), patch.object(
         WorkloadManager, "_alertmanager_version", property(lambda *_: "0.0.0")
     ), patch("subprocess.run"):
         yield AlertmanagerCharm

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -4,7 +4,7 @@ import pytest
 from charms.tempo_coordinator_k8s.v0.charm_tracing import charm_tracing_disabled
 from ops.testing import Context
 
-from alertmanager import Alertmanager, WorkloadManager
+from alertmanager import WorkloadManager
 from src.charm import AlertmanagerCharm
 
 

--- a/tests/unit/test_config_changes.py
+++ b/tests/unit/test_config_changes.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+# Copyright 2021 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Unit tests for config change detection."""
+
+import dataclasses
+import unittest
+from unittest.mock import MagicMock, patch
+
+import ops
+import pytest
+from helpers import begin_with_initial_hooks_isolated
+from ops.pebble import PathError
+
+from alertmanager import ConfigFileSystemState, WorkloadManager
+
+ops.testing.SIMULATE_CAN_CONNECT = True  # pyright: ignore
+CONTAINER_NAME = "alertmanager"
+
+
+class TestConfigFileSystemStateHasChanges(unittest.TestCase):
+    """Tests for ConfigFileSystemState.has_changes()."""
+
+    def setUp(self):
+        self.container = MagicMock()
+
+    def test_file_does_not_exist(self):
+        """A file that doesn't exist in the container is a change."""
+        self.container.pull.side_effect = PathError("not found", "not found")
+        manifest = ConfigFileSystemState({"/etc/config.yml": "content"})
+        self.assertTrue(manifest.has_changes(self.container))
+
+    def test_file_exists_with_same_content(self):
+        """A file with identical content is not a change."""
+        self.container.pull.return_value.read.return_value = "content"
+        manifest = ConfigFileSystemState({"/etc/config.yml": "content"})
+        self.assertFalse(manifest.has_changes(self.container))
+
+    def test_file_exists_with_different_content(self):
+        """A file with different content is a change."""
+        self.container.pull.return_value.read.return_value = "old content"
+        manifest = ConfigFileSystemState({"/etc/config.yml": "new content"})
+        self.assertTrue(manifest.has_changes(self.container))
+
+    def test_file_should_be_removed_and_exists(self):
+        """A file marked for removal that still exists is a change."""
+        self.container.pull.return_value.read.return_value = "content"
+        manifest = ConfigFileSystemState({"/etc/config.yml": None})
+        self.assertTrue(manifest.has_changes(self.container))
+
+    def test_file_should_be_removed_and_does_not_exist(self):
+        """A file marked for removal that is already gone is not a change."""
+        self.container.pull.side_effect = PathError("not found", "not found")
+        manifest = ConfigFileSystemState({"/etc/config.yml": None})
+        self.assertFalse(manifest.has_changes(self.container))
+
+    def test_multiple_files_no_changes(self):
+        """Multiple files all matching is not a change."""
+        self.container.pull.return_value.read.return_value = "content"
+        manifest = ConfigFileSystemState({
+            "/etc/config.yml": "content",
+            "/etc/other.yml": "content",
+        })
+        self.assertFalse(manifest.has_changes(self.container))
+
+    def test_multiple_files_one_change(self):
+        """One differing file among many is a change."""
+        def pull_side_effect(path):
+            mock = MagicMock()
+            if path == "/etc/config.yml":
+                mock.read.return_value = "old content"
+            else:
+                mock.read.return_value = "content"
+            return mock
+
+        self.container.pull.side_effect = pull_side_effect
+        manifest = ConfigFileSystemState({
+            "/etc/config.yml": "new content",
+            "/etc/other.yml": "content",
+        })
+        self.assertTrue(manifest.has_changes(self.container))
+
+
+class TestCharmReloadConditional:
+    """Tests that charm only reloads when config actually changes."""
+
+    @pytest.fixture
+    def initial_state(self, context):
+        return begin_with_initial_hooks_isolated(context, leader=True)
+
+    def test_common_exit_hook_reloads_on_config_change(self, context, initial_state):
+        """_common_exit_hook reloads when config changes."""
+        with patch.object(WorkloadManager, "reload") as mock_reload:
+            # Change config from default
+            state = dataclasses.replace(
+                initial_state,
+                config={"config_file": "global:\n  resolve_timeout: 10m\n"}
+            )
+            state = context.run(context.on.config_changed(), state)
+            # Config changed from default, so reload should be called
+            mock_reload.assert_called_once()

--- a/tests/unit/test_config_changes.py
+++ b/tests/unit/test_config_changes.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright 2021 Canonical Ltd.
+# Copyright 2026 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 """Unit tests for config change detection."""

--- a/tests/unit/test_server_scheme.py
+++ b/tests/unit/test_server_scheme.py
@@ -35,7 +35,7 @@ class TestServerScheme:
             state = begin_with_initial_hooks_isolated(context, leader=leader)
 
             # Add relation
-            prom_rel = Relation("alerting", id=10)
+            prom_rel = Relation("alerting", id=100)
             state = add_relation_sequence(context, state, prom_rel)
             yield state  # keep the patch active for so long as this fixture is needed  # pyright:ignore
 


### PR DESCRIPTION
Fixes #436 

## 1. Skip reload when configuration hasn't changed
### Problem
alertmanager was being reloaded on every hook execution, even when the generated configuration was identical to what was already on disk. This caused unnecessary workload disruption.

### Solution
Added `ConfigFileSystemState.has_changes(container)` to compare the generated manifest against the actual filesystem state in the workload container. The charm's _common_exit_hook()] only calls reload() when there's an actual change

## 2. Fix non-deterministic config output (group_by sorting)
### Problem
The `group_by` field in the generated alertmanager route was emitted as an unsorted list. Because the order depended on set/dict iteration, the config file would flap, triggering unnecessary reloads (flagged by flaplint).
```
../alertmanager-k8s-operator/src/config_builder.py  · 1 error(s)
  ✖ 107:24  unsorted iteration into a sequence · group_by → on-disk file  [high]
            a value built from an unordered source is iterated over at `group_by`
            without sorted() to build an order-dependent sequence that reaches an
            on-disk file. Sort the collection before iterating.

────────────────────────────────────────────────────────
  ✖ 9 problem(s)   1 error(s)   8 warning(s)   · 17 file(s) scanned
```

## 3. Use internal URL for reload API calls
### Problem
Reloading used the external URL (ingress) to send the request to alertmanager itself. When ingress was configured with TLS using a custom CA, alertmanager had no way to verify that CA and the reload request would fail.

## Solution
reload() now uses the in-cluster service FQDN instead of the external ingress URL. The internal URL uses the same CA certificate that the workload is already configured with, so TLS verification succeeds.