### PR TITLE
test: adopt -Werror in unit tests

### DIFF
--- a/lib/charms/karma_k8s/v0/karma_dashboard.py
+++ b/lib/charms/karma_k8s/v0/karma_dashboard.py
@@ -26,6 +26,7 @@ import logging
 from typing import Any, Dict, List, Optional
 
 import ops.charm
+import pydantic
 from ops.charm import CharmBase, RelationJoinedEvent, RelationRole
 from ops.framework import EventBase, EventSource, Object, ObjectEvents, StoredState
 from pydantic import BaseModel, ValidationError
@@ -38,7 +39,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 9
+LIBPATCH = 10
 
 PYDEPS = ["pydantic < 2"]
 
@@ -47,19 +48,46 @@ INTERFACE_NAME = "karma_dashboard"
 
 logger = logging.getLogger(__name__)
 
+# This library was written against pydantic v1, but charms that vendor it may install
+# pydantic v2 (it is a transitive dependency of several common charm libs). Under v2 the
+# v1-style class-based `Config` raises ``PydanticDeprecatedSince20``, which a charm running
+# its tests under ``-W error`` would surface as a hard error at import time.
+PYDANTIC_V2 = int(pydantic.version.VERSION.split(".")[0]) >= 2
 
-class _KarmaDashboardProviderUnitDataV0(BaseModel):
-    name: str
-    uri: str
-    cluster: str = ""
-    proxy: bool = True
 
-    class Config:
-        json_encoders = {
-            # We need this because relation data values must be strings, not <class 'bool'>
-            # Note: In pydantic>=2, can use `field_serializer`.
-            bool: lambda v: "true" if v else "false"
-        }
+def _model_dump(model: BaseModel) -> Dict[str, Any]:
+    """Dump a pydantic model to a dict, across pydantic v1 and v2."""
+    return model.model_dump() if PYDANTIC_V2 else model.dict()
+
+
+if PYDANTIC_V2:
+
+    class _KarmaDashboardProviderUnitDataV0(BaseModel):
+        name: str
+        uri: str
+        cluster: str = ""
+        proxy: bool = True
+
+        # Under pydantic v1 the ``Config.json_encoders`` below coerced ``bool`` to the
+        # ``"true"``/``"false"`` strings that relation data requires. That coercion is only
+        # consulted by ``.json()``, which this library never calls -- callers convert ``proxy``
+        # to a string explicitly (see ``_set_alertmanager_data``) -- so under v2 no custom
+        # serializer config is needed, and omitting it avoids the deprecated class-based config.
+
+else:
+
+    class _KarmaDashboardProviderUnitDataV0(BaseModel):  # type: ignore[no-redef]
+        name: str
+        uri: str
+        cluster: str = ""
+        proxy: bool = True
+
+        class Config:
+            json_encoders = {
+                # We need this because relation data values must be strings, not <class 'bool'>
+                # Note: In pydantic>=2, can use `field_serializer`.
+                bool: lambda v: "true" if v else "false"
+            }
 
 
 class KarmaAlertmanagerConfigChanged(EventBase):
@@ -212,7 +240,7 @@ class KarmaConsumer(RelationManagerBase):
                         )
                     else:
                         # Now convert relation data into config file format. Luckily it's trivial.
-                        config = data.dict()
+                        config = _model_dump(data)
                         if config and config not in servers:
                             servers.append(config)
 
@@ -328,8 +356,7 @@ class KarmaProvider(RelationManagerBase):
             cluster=f"{self.charm.model.name}_{self.charm.app.name}",
             proxy=True,
         )
-        # TODO Use `data.model_dump()` when we switch to pydantic 2
-        as_dict = data.dict()
+        as_dict = _model_dump(data)
         # Replace bool with str, otherwise:
         # ops.model.RelationDataTypeError: relation data values must be strings, not <class 'bool'>
         as_dict["proxy"] = "true" if as_dict["proxy"] else "false"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ version = "0.0"
 requires-python = "~=3.14.0"
 
 dependencies = [
-  "ops[tracing]",
+  "ops[tracing]>=3.8",
   "pyyaml",
   "lightkube>=0.11",  # observability_libs
   "lightkube-models",  # observability_libs
@@ -32,7 +32,7 @@ dev = [
   "deepdiff",
   "hypothesis",
   "validators>=0.21.2",
-  "ops[testing]",
+  "ops[testing]>=3.8",
   "pytest-interface-tester>0.3",
   # Integration
   "pytest-jubilant",
@@ -74,7 +74,7 @@ convention = "google"
 # Static analysis tools configuration
 [tool.pyright]
 extraPaths = ["src", "lib"]
-pythonVersion = "3.8"
+pythonVersion = "3.14"
 pythonPlatform = "All"
 exclude = [
   "tests/integration/remote_configuration_tester/**",
@@ -84,6 +84,33 @@ exclude = [
 minversion = "6.0"
 log_cli_level = "INFO"
 addopts = "--tb=native --verbose --capture=no --log-cli-level=INFO"
+# Treat warnings (deprecations, ResourceWarnings, etc.) as errors so the unit suite catches
+# them before they become breakages. Every ignore below is narrow and justified; see the
+# Charm Tech -Werror rollout notes.
+filterwarnings = [
+    "error",
+    # -- Deprecations owned by other (vendored) charm libs. The real fix belongs upstream; until
+    #    those libs are released we cannot promote these to errors here. --
+    # charms.tempo_coordinator_k8s.v0.tracing still uses pydantic-v1 idioms under pydantic v2.
+    # Upstream: canonical/tempo-coordinator-k8s-operator.
+    "ignore:The .__fields__. attribute is deprecated:DeprecationWarning",
+    "ignore:Accessing the 'model_fields' attribute on the instance is deprecated:DeprecationWarning",
+    "ignore:The .dict. method is deprecated:DeprecationWarning",
+    # charms.loki_k8s.v1.loki_push_api and charms.tls_certificates_interface.v4.tls_certificates
+    # call the deprecated ops JujuVersion.from_environ().
+    # Upstream: canonical/loki-k8s-operator, canonical/tls-certificates-interface.
+    "ignore:JujuVersion.from_environ:DeprecationWarning",
+    # charms.tls_certificates_interface.v4.tls_certificates calls the deprecated cryptography
+    # generate_private_key(). Upstream: canonical/tls-certificates-interface.
+    "ignore:generate_private_key:DeprecationWarning",
+    # -- Intentional ops deprecation: these tests still use Harness. Migrating them to
+    #    Scenario (Context) would remove this; tracked as a follow-up. --
+    "ignore:Harness is deprecated:PendingDeprecationWarning",
+    # urllib's HTTPError finalizer emits a ResourceWarning on Python 3.14 when a unit-test mock
+    # raises HTTPError(fp=None) (tests/unit/test_alertmanager_client.py); a test/stdlib artifact,
+    # not a charm resource leak.
+    "ignore:Implicitly cleaning up <HTTPError:ResourceWarning",
+]
 
 [tool.codespell]
 skip = ".git,.tox,build,venv*"

--- a/src/alertmanager.py
+++ b/src/alertmanager.py
@@ -58,7 +58,8 @@ class ConfigFileSystemState:
         """Return True if any file in the manifest differs from what's in the container."""
         for filepath, content in self._manifest.items():
             try:
-                existing = container.pull(filepath).read()
+                with container.pull(filepath) as f:
+                    existing = f.read()
             except PathError:
                 existing = None
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -374,20 +374,20 @@ class AlertmanagerCharm(CharmBase):
         filepaths = self._render_manifest().manifest.keys()
 
         try:
-            results = [
-                {
-                    "path": filepath,
-                    "content": str(self.container.pull(filepath).read()),
-                }
-                for filepath in filepaths
-                if self.container.exists(filepath)
-            ]
-            content = self.container.pull(self._config_path)
+            results = []
+            for filepath in filepaths:
+                if self.container.exists(filepath):
+                    # Close the pulled file handle promptly; otherwise it is left for the
+                    # garbage collector, which emits a ResourceWarning (an error under -W error).
+                    with self.container.pull(filepath) as f:
+                        results.append({"path": filepath, "content": str(f.read())})
+            with self.container.pull(self._config_path) as content:
+                config_content = str(content.read())
             # juju requires keys to be lowercase alphanumeric (can't use self._config_path)
             event.set_results(
                 {
                     "path": self._config_path,
-                    "content": str(content.read()),
+                    "content": config_content,
                     # This already includes the above, but keeping both for backwards compat.
                     "configs": str(results),
                 }

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -84,9 +84,8 @@ class TestWithInitialHooks(unittest.TestCase):
     def test_topology_added_if_user_provided_config_without_group_by(self, *unused):
         new_config = yaml.dump({"not a real config": "but good enough for testing"})
         self.harness.update_config({"config_file": new_config})
-        updated_config = yaml.safe_load(
-            self.harness.charm.container.pull(self.harness.charm._config_path)
-        )
+        with self.harness.charm.container.pull(self.harness.charm._config_path) as f:
+            updated_config = yaml.safe_load(f)
 
         self.assertEqual(updated_config["not a real config"], "but good enough for testing")
         self.assertListEqual(
@@ -100,9 +99,8 @@ class TestWithInitialHooks(unittest.TestCase):
     def test_topology_added_if_user_provided_config_with_group_by(self, *unused):
         new_config = yaml.dump({"route": {"group_by": ["alertname", "juju_model"]}})
         self.harness.update_config({"config_file": new_config})
-        updated_config = yaml.safe_load(
-            self.harness.charm.container.pull(self.harness.charm._config_path)
-        )
+        with self.harness.charm.container.pull(self.harness.charm._config_path) as f:
+            updated_config = yaml.safe_load(f)
 
         self.assertListEqual(
             sorted(updated_config["route"]["group_by"]),
@@ -119,9 +117,8 @@ class TestWithInitialHooks(unittest.TestCase):
         """
         new_config = yaml.dump({"route": {"group_by": ["..."]}})
         self.harness.update_config({"config_file": new_config})
-        updated_config = yaml.safe_load(
-            self.harness.charm.container.pull(self.harness.charm._config_path)
-        )
+        with self.harness.charm.container.pull(self.harness.charm._config_path) as f:
+            updated_config = yaml.safe_load(f)
 
         self.assertListEqual(
             updated_config["route"]["group_by"],
@@ -162,12 +159,11 @@ class TestWithInitialHooks(unittest.TestCase):
         self.harness.update_config({"config_file": new_config})
         templates = '{{ define "some.tmpl.variable" }}whatever it is{{ end}}'
         self.harness.update_config({"templates_file": templates})
-        updated_templates = self.harness.charm.container.pull(self.harness.charm._templates_path)
-        self.assertEqual(templates, updated_templates.read())
+        with self.harness.charm.container.pull(self.harness.charm._templates_path) as f:
+            self.assertEqual(templates, f.read())
 
-        updated_config = yaml.safe_load(
-            self.harness.charm.container.pull(self.harness.charm._config_path)
-        )
+        with self.harness.charm.container.pull(self.harness.charm._config_path) as f:
+            updated_config = yaml.safe_load(f)
         self.assertEqual(updated_config["templates"], [f"{self.harness.charm._templates_path}"])
 
 

--- a/tests/unit/test_config_changes.py
+++ b/tests/unit/test_config_changes.py
@@ -24,6 +24,11 @@ class TestConfigFileSystemStateHasChanges(unittest.TestCase):
 
     def setUp(self):
         self.container = MagicMock()
+        # has_changes() uses `with container.pull(p) as f: f.read()`, so make the
+        # pull result a context manager that yields itself; tests configure .read on it.
+        pull_result = self.container.pull.return_value
+        pull_result.__enter__.return_value = pull_result
+        pull_result.__exit__.return_value = False
 
     def test_file_does_not_exist(self):
         """A file that doesn't exist in the container is a change."""
@@ -68,6 +73,8 @@ class TestConfigFileSystemStateHasChanges(unittest.TestCase):
         """One differing file among many is a change."""
         def pull_side_effect(path):
             mock = MagicMock()
+            mock.__enter__.return_value = mock
+            mock.__exit__.return_value = False
             if path == "/etc/config.yml":
                 mock.read.return_value = "old content"
             else:

--- a/tests/unit/test_push_config_to_workload_on_startup.py
+++ b/tests/unit/test_push_config_to_workload_on_startup.py
@@ -54,15 +54,13 @@ class TestPushConfigToWorkloadOnStartup(unittest.TestCase):
         self.harness.set_leader(is_leader)
 
         # THEN amtool config is rendered
-        amtool_config = yaml.safe_load(
-            self.harness.charm.container.pull(self.harness.charm._amtool_config_path)
-        )
+        with self.harness.charm.container.pull(self.harness.charm._amtool_config_path) as f:
+            amtool_config = yaml.safe_load(f)
         self.assertTrue(validators.url(amtool_config["alertmanager.url"], simple_host=True))
 
         # AND alertmanager config is rendered
-        am_config = yaml.safe_load(
-            self.harness.charm.container.pull(self.harness.charm._config_path)
-        )
+        with self.harness.charm.container.pull(self.harness.charm._config_path) as f:
+            am_config = yaml.safe_load(f)
         self.assertGreaterEqual(am_config.keys(), {"global", "route", "receivers"})
 
         # AND path to config file is part of pebble layer command

--- a/tests/unit/test_remote_configuration_requirer.py
+++ b/tests/unit/test_remote_configuration_requirer.py
@@ -99,10 +99,11 @@ class TestAlertmanagerRemoteConfigurationRequirer(unittest.TestCase):
             app_or_unit="remote-config-provider",
             key_values={"alertmanager_config": json.dumps(remote_config)},
         )
-        config = self.harness.charm.container.pull(self.harness.charm._config_path)
+        with self.harness.charm.container.pull(self.harness.charm._config_path) as config:
+            actual_config = yaml.safe_load(config.read())
 
         self.assertEqual(
-            DeepDiff(yaml.safe_load(config.read()), expected_config, ignore_order=True),
+            DeepDiff(actual_config, expected_config, ignore_order=True),
             {},
         )
 
@@ -137,9 +138,8 @@ class TestAlertmanagerRemoteConfigurationRequirer(unittest.TestCase):
             app_or_unit="remote-config-provider",
             key_values={"alertmanager_config": json.dumps(invalid_config)},
         )
-        config = self.harness.charm.container.pull(self.harness.charm._config_path)
-
-        self.assertNotIn("invalid_config", yaml.safe_load(config.read()))
+        with self.harness.charm.container.pull(self.harness.charm._config_path) as config:
+            self.assertNotIn("invalid_config", yaml.safe_load(config.read()))
 
     @patch.object(WorkloadManager, "check_config", lambda *a, **kw: ("ok", ""))
     @k8s_resource_multipatch
@@ -158,6 +158,5 @@ class TestAlertmanagerRemoteConfigurationRequirer(unittest.TestCase):
                 "alertmanager_templates": json.dumps([test_template]),
             },
         )
-        updated_templates = self.harness.charm.container.pull(self.harness.charm._templates_path)
-
-        self.assertEqual(updated_templates.read(), test_template)
+        with self.harness.charm.container.pull(self.harness.charm._templates_path) as updated_templates:
+            self.assertEqual(updated_templates.read(), test_template)

--- a/tests/unit/test_self_scrape_jobs.py
+++ b/tests/unit/test_self_scrape_jobs.py
@@ -23,7 +23,10 @@ class TestWithInitialHooks(unittest.TestCase):
         self.addCleanup(self.harness.cleanup)
 
         self.harness.set_leader(True)
-        self.app_name = "am"
+        # The "replicas" peer relation's remote app is this charm's own app; using a name
+        # other than the real app name makes Harness emit a "Remote unit name invalid"
+        # UserWarning (an error under -W error).
+        self.app_name = "alertmanager-k8s"
         # Create the peer relation before running harness.begin_with_initial_hooks(), because
         # otherwise it will create it for you and we don't know the rel_id
         self.peer_rel_id = self.harness.add_relation("replicas", self.app_name)

--- a/uv.lock
+++ b/uv.lock
@@ -54,8 +54,8 @@ requires-dist = [
     { name = "lightkube", specifier = ">=0.11" },
     { name = "lightkube-extensions" },
     { name = "lightkube-models" },
-    { name = "ops", extras = ["testing"], marker = "extra == 'dev'" },
-    { name = "ops", extras = ["tracing"] },
+    { name = "ops", extras = ["testing"], marker = "extra == 'dev'", specifier = ">=3.8" },
+    { name = "ops", extras = ["tracing"], specifier = ">=3.8" },
     { name = "pydantic", specifier = ">=2" },
     { name = "pyright", marker = "extra == 'dev'", specifier = "<1.1.399" },
     { name = "pytest", marker = "extra == 'dev'" },
@@ -182,15 +182,14 @@ wheels = [
 
 [[package]]
 name = "charmed-service-mesh-helpers"
-version = "0.6.0"
+version = "0.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ops" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b9/b1/01f400a87af69198f90abfd74d4f9e53878fb015e6ccb61ebbc4370dcf6b/charmed_service_mesh_helpers-0.6.0.tar.gz", hash = "sha256:2a606679c467c68744d439641aa8fe9fc533eebfaea97fc3662e87266fd0d786", size = 16869, upload-time = "2026-03-17T12:19:59Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e5/4f/c1f866c0483e6c19f733dc9d8946453c41c2ed63177a8716490ac37d7ce1/charmed_service_mesh_helpers-0.2.0.tar.gz", hash = "sha256:4e62fe6f917d4933610c2f8cfb30a90d46ea026fa302988cffb879abd423ca5a", size = 15348, upload-time = "2025-09-05T13:12:34.329Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b9/57/f3432cace60a3116bb7f9b98aae42638278777da3fdf78aa49e974d43920/charmed_service_mesh_helpers-0.6.0-py3-none-any.whl", hash = "sha256:7160e5c1585efd2e369ccc6257c8e5964bbc52bce21a053ccba010e29b1fb12a", size = 16436, upload-time = "2026-03-17T12:19:59.667Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/df/dc7086366b212da07ef027e3cc48824dc6a7b1193badc3879d231f6a4ef3/charmed_service_mesh_helpers-0.2.0-py3-none-any.whl", hash = "sha256:913e2a5bfb2db445e4b95085f8c2a8b4dea1036beedd229efca9217877c1da15", size = 13967, upload-time = "2025-09-05T13:12:33.237Z" },
 ]
 
 [[package]]
@@ -504,18 +503,6 @@ wheels = [
 ]
 
 [[package]]
-name = "importlib-metadata"
-version = "9.0.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "zipp" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/a9/01/15bb152d77b21318514a96f43af312635eb2500c96b55398d020c93d86ea/importlib_metadata-9.0.0.tar.gz", hash = "sha256:a4f57ab599e6a2e3016d7595cfd72eb4661a5106e787a95bcc90c7105b831efc", size = 56405, upload-time = "2026-03-20T06:42:56.999Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/38/3d/2d244233ac4f76e38533cfcb2991c9eb4c7bf688ae0a036d30725b8faafe/importlib_metadata-9.0.0-py3-none-any.whl", hash = "sha256:2d21d1cc5a017bd0559e36150c21c830ab1dc304dedd1b7ea85d20f45ef3edd7", size = 27789, upload-time = "2026-03-20T06:42:55.665Z" },
-]
-
-[[package]]
 name = "iniconfig"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -705,17 +692,16 @@ wheels = [
 
 [[package]]
 name = "ops"
-version = "2.23.2"
+version = "3.8.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "importlib-metadata" },
     { name = "opentelemetry-api" },
     { name = "pyyaml" },
     { name = "websocket-client" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/93/98/84789a5e15ad76e043301bbd70b4d39cffaa717ae6eecb662fd0dd0cc7af/ops-2.23.2.tar.gz", hash = "sha256:a69b0c5bc65ebd91720fc96459e81b969df851f3a6c9c855ee73de7004205987", size = 528074, upload-time = "2026-02-11T03:58:15.565Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/49/e4/70ed4f3dc41b2d626ef38ffc7c2418b680f0c7f0ddf0a4410572903734df/ops-3.8.0.tar.gz", hash = "sha256:bdbf4bbcd0622acade9ef0b156ddefc31be59f0ef55d563081a094cf7dd6665c", size = 606170, upload-time = "2026-06-30T03:24:48.612Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e0/00/65da7c96d0f9e13c4de3bdd2e3717259fe723ff4bd4e5dc714164f851032/ops-2.23.2-py3-none-any.whl", hash = "sha256:9cab0c6bc46eeff2e96777128200c3ef872b55641b12f07dc4fd6fe3103954be", size = 188415, upload-time = "2026-02-11T03:58:13.693Z" },
+    { url = "https://files.pythonhosted.org/packages/46/70/234d31bdee92d89fd7a4e0944283469a88fad5ea23e2ad449d6ce1256b53/ops-3.8.0-py3-none-any.whl", hash = "sha256:03f788091b10c5ed37a0a290e814b1a90aa0dcec6006a87875a085072df2261d", size = 215545, upload-time = "2026-06-30T03:24:43.916Z" },
 ]
 
 [package.optional-dependencies]
@@ -728,29 +714,31 @@ tracing = [
 
 [[package]]
 name = "ops-scenario"
-version = "7.23.2"
+version = "8.8.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "ops" },
     { name = "pyyaml" },
+    { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ee/e7/1514b9c27b9364ec1d04791b0fb76d1a629c8cc73f90fbf6dd867457c914/ops_scenario-7.23.2.tar.gz", hash = "sha256:327dda8b3c871ccf16246ed4f8c7e093526af42093549976596cede58cbc8488", size = 70017, upload-time = "2026-02-11T03:58:16.553Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/64/43/0f12c71563810b5121b2f9432890c517f8f97f592cc86a1ea6c7835ef5c9/ops_scenario-8.8.0.tar.gz", hash = "sha256:3140fe256c68ac4d2d498cfe1cadb7f7e8a0a9687090bb137883ad8b7096cb96", size = 83463, upload-time = "2026-06-30T03:24:49.733Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/01/15/3b59993cad1b2838c9bb20f6f2ed5297fcf490025b1ffecc27d06be1daba/ops_scenario-7.23.2-py3-none-any.whl", hash = "sha256:024b638e0ea94e8f2e3c642d4f96031b0c7ac4f39117b97107dc9a09503651b4", size = 64328, upload-time = "2026-02-11T03:58:14.916Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/db/adf8fa05fc609d9a261c28b6b320c140eb635a95e056f5a2f9ae255c6aff/ops_scenario-8.8.0-py3-none-any.whl", hash = "sha256:088f0c5713d330b92762c4853a32a9482f4a162667d9d475edf924ce2510a3f0", size = 72696, upload-time = "2026-06-30T03:24:45.626Z" },
 ]
 
 [[package]]
 name = "ops-tracing"
-version = "2.23.2"
+version = "3.8.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "opentelemetry-api" },
     { name = "opentelemetry-sdk" },
     { name = "ops" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7e/7a/fd22f7276ad3cd3d5eb32fbdbe099d1fad8b14b4fe7d42f99e59b3f5df15/ops_tracing-2.23.2.tar.gz", hash = "sha256:888724dbb953329b9aa6d19d69e185db40f5a6f91729916f57e3c2f59c590fa4", size = 28430, upload-time = "2026-02-11T04:38:32.181Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/60/44/d8c1dffecc4a945875a8506dc4863bd9a17e867f880b266e2f0477f890ef/ops_tracing-3.8.0.tar.gz", hash = "sha256:eafc70935e5303d72466cb331bc2d3807fa34e4ddb25a71cc6c1095e6d42d205", size = 28701, upload-time = "2026-06-30T03:24:50.69Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cd/e7/5447c80c6c013cf08d0d6f8182af965e00ef41171b2f62713fd938bcecbf/ops_tracing-2.23.2-py3-none-any.whl", hash = "sha256:74cd11b34e9524fb999d045d4a7a626cab264d8080dd7baa67656636010bdceb", size = 31391, upload-time = "2026-02-11T04:38:31.086Z" },
+    { url = "https://files.pythonhosted.org/packages/73/73/a4a0178c2938cce01b48856d8d5bbc3823fcdec6b3e271226a8f35ce21f5/ops_tracing-3.8.0-py3-none-any.whl", hash = "sha256:e0129caad0d361b52d956194efbfce18d2dfd6ac3cea7836b654a12ca78c3141", size = 31545, upload-time = "2026-06-30T03:24:47.005Z" },
 ]
 
 [[package]]
@@ -1188,13 +1176,4 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c7/79/12135bdf8b9c9367b8701c2c19a14c913c120b882d50b014ca0d38083c2c/wsproto-1.3.2.tar.gz", hash = "sha256:b86885dcf294e15204919950f666e06ffc6c7c114ca900b060d6e16293528294", size = 50116, upload-time = "2025-11-20T18:18:01.871Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a4/f5/10b68b7b1544245097b2a1b8238f66f2fc6dcaeb24ba5d917f52bd2eed4f/wsproto-1.3.2-py3-none-any.whl", hash = "sha256:61eea322cdf56e8cc904bd3ad7573359a242ba65688716b0710a5eb12beab584", size = 24405, upload-time = "2025-11-20T18:18:00.454Z" },
-]
-
-[[package]]
-name = "zipp"
-version = "4.1.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b9/d8/eab98a517c14134c0b2eb4e2387bc5f457334293ec5d2dd3857ec2966802/zipp-4.1.0.tar.gz", hash = "sha256:4cb57381f544315db7688e976e922a2b18cdb513d21cc194eb42232ba2a3e602", size = 26214, upload-time = "2026-05-18T20:08:57.967Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3a/13/547360d81e6d88d58492968ffda9f9542854f11310ee556fef14260cc886/zipp-4.1.0-py3-none-any.whl", hash = "sha256:25ad4e16390cd314347dd8f1de67a2ac538ae658ed4ab9db16029c07c188e97f", size = 10238, upload-time = "2026-05-18T20:08:57.045Z" },
 ]


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->

Find out about issues that come from warnings while tests are running.

## Solution
<!-- A summary of the solution addressing the above issue -->

Promote warnings to errors in the unit suite via filterwarnings = ["error", ...] in [tool.pytest.ini_options], and fix everything fixable in this repo so the suite is green under it:

- karma_dashboard lib: guard the v1-style class-based pydantic Config (and the .dict() calls) for pydantic v2, which otherwise raises PydanticDeprecatedSince20 at import (LIBPATCH 9 -> 10; the fix belongs upstream in canonical/karma-operator).
- src/charm.py: close the container.pull() handles in the show-config action (a real ResourceWarning leak), and the equivalent handles in the unit tests.
- test_self_scrape_jobs: use the charm's real app name for the peer relation so Harness no longer warns about an invalid remote unit name.

The remaining ignores are narrow and individually justified: vendored-lib deprecations owned upstream (tempo tracing, loki, tls), the intentional Harness deprecation, and a py3.14 urllib HTTPError finalizer artifact.

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->

[Discourse post](https://discourse.charmhub.io/t/catch-problems-before-they-bite-turn-on-werror-in-your-charms-unit-tests/20618?u=tony-meyer)

## Testing Instructions
<!-- What steps need to be taken to test this PR? -->

Verify that the tests run successfully/

## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->

N/A