### PR TITLE
docs: update show-config example to Juju 3.x syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ To verify Alertmanager is using the expected configuration you can use the
 [`show-config`](https://charmhub.io/alertmanager-k8s/actions#show-config) action:
 
 ```shell
-juju run-action alertmanager-k8s/0 show-config --wait
+juju run alertmanager-k8s/0 show-config
 ```
 
 


### PR DESCRIPTION
## Issue

The README `show-config` example uses `juju run-action alertmanager-k8s/0 show-config --wait`, which was removed in Juju 3.x. Following the current docs on Juju 3.x fails with `ERROR unrecognized command: juju run-action`.

Fixes #429.

## Solution

Replace the deprecated invocation with the Juju 3.x equivalent:

```shell
juju run alertmanager-k8s/0 show-config
```

`juju run` is synchronous by default, so `--wait` is not needed.

## Context

`juju run-action` and its `--wait` flag were removed in Juju 3.x. The replacement is `juju run`, which is synchronous by default. The `show-config` action itself is unchanged (defined at `charmcraft.yaml:248` and handled in `src/charm.py:368` via `_on_show_config_action`) — only the doc example is stale.

## Testing Instructions

Docs-only change — no functional code was modified. Verify by inspection:

```bash
grep -n 'run-action' README.md  # should return no results after the fix
sed -n '92,100p' README.md      # confirm the updated block looks correct
```

## Upgrade Notes

N/A — documentation fix only, no charm behaviour changed.
