### PR TITLE
feat: add silence-expiry exporter sidecar with expiry alerting

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,9 +191,25 @@ juju refresh alertmanager-k8s \
   --resource alertmanager-image=quay.io/prometheus/alertmanager
 ```
 
+The charm also runs a small **silence-expiry exporter** as a sidecar container
+(`silence-exporter`), backed by the Canonical-maintained [ubuntu/python] rock.
+The exporter polls the local Alertmanager API for active silences and exposes,
+on port `9095`, an `alertmanager_silence_endsat_timestamp_seconds` metric per
+active silence (plus an `alertmanager_silence_exporter_scrape_error` self-health
+metric). These are scraped automatically as a second job on the existing
+`self-metrics-endpoint` relation, and a built-in `SilenceExpiringSoon` alert
+rule fires when a silence is due to expire within the next 72 hours.
+
+To limit cardinality, only the `id` and `created_by` labels are exposed (the
+free-text `comment` is deliberately dropped). Note that silences are
+HA-replicated across units, so in a clustered deployment every unit's exporter
+reports the same silences; the resulting series are distinguished by the
+`instance` label.
+
 
 [ubuntu/prometheus-alertmanager]: https://hub.docker.com/r/ubuntu/prometheus-alertmanager
 [quay.io/prometheus/alertmanager]: https://quay.io/repository/prometheus/alertmanager?tab=tags
+[ubuntu/python]: https://hub.docker.com/r/ubuntu/python
 
 
 ## Official alertmanager documentation

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -54,6 +54,11 @@ containers:
         # across container restarts.
         # This path is passed to alertmanager via the `--storage.path` cli argument.
         location: /alertmanager
+  silence-exporter:  # container key used by pebble
+    resource: silence-exporter-image
+    # Sidecar that polls the local Alertmanager API for active silences and exposes their
+    # expiry timestamps as Prometheus metrics on :9095. The exporter script is pushed from the
+    # charm (same pattern used for config files) and run by Pebble.
 
 storage:
   data:
@@ -181,6 +186,17 @@ resources:
       - location of executable "alertmanager" is in the path
       - has `update-ca-certificates`
     upstream-source: ubuntu/alertmanager@sha256:6d137784294d137394683ec56519eafce6d0bd91c4c62439197bb1c898d1a76e  # renovate: oci-image tag: 0.31-26.04
+  silence-exporter-image:
+    type: oci-image
+    description: |
+      OCI image hosting the silence-expiry exporter sidecar. This is a Canonical-maintained
+      chiselled Python rock (https://hub.docker.com/r/ubuntu/python). The charm makes the
+      following assumptions about the image:
+      - `python3` is on the PATH
+      - Pebble is the entrypoint (standard for Canonical rocks)
+      The exporter itself is pushed to the container by the charm and needs only the Python
+      standard library (no pip dependencies).
+    upstream-source: ubuntu/python:3.12-24.04_stable  # renovate: oci-image tag: 3.12-24.04
 
 config:
   options:

--- a/src/charm.py
+++ b/src/charm.py
@@ -51,7 +51,7 @@ from ops.model import (
     Relation,
     WaitingStatus,
 )
-from ops.pebble import PathError, ProtocolError  # type: ignore
+from ops.pebble import ChangeError, Layer, PathError, ProtocolError  # type: ignore
 
 from alertmanager import (
     ConfigFileSystemState,
@@ -83,7 +83,17 @@ class AlertmanagerCharm(CharmBase):
     _relations = SimpleNamespace(
         alerting="alerting", peer="replicas", remote_config="remote_configuration"
     )
-    _ports = SimpleNamespace(api=9093, ha=9094)
+    _ports = SimpleNamespace(api=9093, ha=9094, exporter=9095)
+
+    # The silence-expiry exporter runs as a sidecar container in the alertmanager pod.
+    _exporter_container_name = _exporter_service_name = "silence-exporter"
+    _exporter_layer_name = "silence-exporter"
+    # Path, inside the sidecar container, where the exporter script is pushed by the charm.
+    _exporter_script_path = "/exporter.py"
+    # Path, inside the sidecar container, where the CA cert is pushed (only used when TLS is on).
+    _exporter_ca_cert_path = "/usr/local/share/ca-certificates/cos-ca.crt"
+    # How often (seconds) the exporter polls the alertmanager API for silences.
+    _exporter_scrape_interval = 30
 
     # path, inside the workload container, to the alertmanager and amtool configuration files
     # the amalgamated templates file goes in the same folder as the main configuration file
@@ -100,6 +110,7 @@ class AlertmanagerCharm(CharmBase):
     def __init__(self, *args):
         super().__init__(*args)
         self.container = self.unit.get_container(self._container_name)
+        self._exporter_container = self.unit.get_container(self._exporter_container_name)
         self._fqdn = socket.getfqdn()
 
         self._csr_attributes = CertificateRequestAttributes(
@@ -208,7 +219,7 @@ class AlertmanagerCharm(CharmBase):
                 ),
                 UnitPolicy(
                     relation="self-metrics-endpoint",
-                    ports=[self.api_port],
+                    ports=[self.api_port, self._ports.exporter],
                 ),
             ],
         )
@@ -242,6 +253,10 @@ class AlertmanagerCharm(CharmBase):
             # a callback).
             self.on.alertmanager_pebble_ready,  # pyright: ignore
             self._on_pebble_ready,
+        )
+        self.framework.observe(
+            self.on.silence_exporter_pebble_ready,  # pyright: ignore
+            self._on_silence_exporter_pebble_ready,
         )
         self.framework.observe(self.on.update_status, self._on_update_status)
         self.framework.observe(self.on.upgrade_charm, self._on_upgrade_charm)
@@ -283,6 +298,7 @@ class AlertmanagerCharm(CharmBase):
         planned_ports = {
             OpenedPort("tcp", self._ports.api),
             OpenedPort("tcp", self._ports.ha),
+            OpenedPort("tcp", self._ports.exporter),
         }
         actual_ports = self.unit.opened_ports()
 
@@ -316,23 +332,38 @@ class AlertmanagerCharm(CharmBase):
 
     @property
     def self_scraping_job(self):
-        """The self-monitoring scrape job."""
+        """The self-monitoring scrape jobs.
+
+        Returns two jobs:
+        - the alertmanager API job (:9093), scraped with the same scheme alertmanager serves; and
+        - the silence-expiry exporter job (:9095), always plaintext http (in-cluster).
+        """
         # We assume that scraping, especially self-monitoring, is in-cluster.
         # This assumption is necessary because the local CA signs CSRs with FQDN as the SAN DNS.
         # If prometheus were to scrape an ingress URL instead, it would error out with:
         # x509: cannot validate certificate.
-        peer_api_netlocs = [
-            f"{hostname}:{self._ports.api}"
-            for hostname in self._get_peer_hostnames(include_this_unit=True)
-        ]
+        peer_hostnames = self._get_peer_hostnames(include_this_unit=True)
+        peer_api_netlocs = [f"{hostname}:{self._ports.api}" for hostname in peer_hostnames]
 
-        config = {
+        alertmanager_job = {
             "scheme": self._scheme,
             "metrics_path": "/metrics",
             "static_configs": [{"targets": peer_api_netlocs}],
         }
 
-        return [config]
+        # Silences are HA-replicated, so every unit's exporter reports the same silences; the
+        # resulting series are distinguished by the `instance` label. The exporter serves plain
+        # http /metrics (in-cluster), independent of alertmanager's TLS state.
+        peer_exporter_netlocs = [
+            f"{hostname}:{self._ports.exporter}" for hostname in peer_hostnames
+        ]
+        exporter_job = {
+            "scheme": "http",
+            "metrics_path": "/metrics",
+            "static_configs": [{"targets": peer_exporter_netlocs}],
+        }
+
+        return [alertmanager_job, exporter_job]
 
     def _resource_reqs_from_config(self) -> ResourceRequirements:
         limits = {
@@ -505,6 +536,67 @@ class AlertmanagerCharm(CharmBase):
 
         return True
 
+    def _silence_exporter_layer(self, environment: dict) -> Layer:
+        """Return the Pebble layer that runs the silence-expiry exporter."""
+        return Layer(
+            {
+                "summary": "silence exporter layer",
+                "description": "pebble config layer for the silence-expiry exporter",
+                "services": {
+                    self._exporter_service_name: {
+                        "override": "replace",
+                        "summary": "alertmanager silence-expiry exporter",
+                        "command": f"python3 {self._exporter_script_path}",
+                        "startup": "enabled",
+                        "environment": environment,
+                    }
+                },
+            }
+        )
+
+    def _configure_silence_exporter(self) -> None:
+        """Push the exporter script (and CA when needed) and (re)configure its Pebble service.
+
+        Mirrors the config-file push pattern used for the alertmanager container: the exporter
+        script lives in the charm source and is pushed into the sidecar, then run by Pebble.
+        """
+        if not self._exporter_container.can_connect():
+            logger.debug("silence-exporter container not ready; skipping configuration")
+            return
+
+        # Push the exporter script from the charm source into the sidecar container.
+        script = (Path(__file__).parent / "silence_exporter.py").read_text()
+        self._exporter_container.push(self._exporter_script_path, script, make_dirs=True)
+
+        environment = {
+            "AM_URL": self._internal_url,
+            "EXPORTER_PORT": str(self._ports.exporter),
+            "SCRAPE_INTERVAL": str(self._exporter_scrape_interval),
+        }
+
+        # When alertmanager serves TLS, the exporter must hit the local API over https and
+        # validate it with the CA. Push the CA into the sidecar and point the exporter at it.
+        if tls_config := self._tls_config:
+            self._exporter_container.push(
+                self._exporter_ca_cert_path, tls_config.ca_cert, make_dirs=True
+            )
+            environment["AM_CA_PATH"] = self._exporter_ca_cert_path
+        else:
+            try:
+                self._exporter_container.remove_path(
+                    self._exporter_ca_cert_path, recursive=True
+                )
+            except (PathError, ProtocolError):
+                pass
+
+        self._exporter_container.add_layer(
+            self._exporter_layer_name, self._silence_exporter_layer(environment), combine=True
+        )
+        try:
+            self._exporter_container.replan()
+        except ChangeError as e:
+            logger.error("Failed to replan silence-exporter: %s", str(e))
+
     def _common_exit_hook(self, update_ca_certs: bool = False) -> None:
         """Event processing hook that is common to all events to ensure idempotency."""
         if not self.resources_patch.is_ready():
@@ -556,6 +648,10 @@ class AlertmanagerCharm(CharmBase):
         if not self._update_workload_config():
             return
 
+        # (Re)configure the silence-expiry exporter sidecar. Done after the workload config so
+        # the exporter picks up the current scheme/url and TLS state.
+        self._configure_silence_exporter()
+
         self.catalog.update_item(item=self._catalogue_item)
 
         self.unit.status = ActiveStatus()
@@ -568,6 +664,10 @@ class AlertmanagerCharm(CharmBase):
 
     def _on_pebble_ready(self, _):
         """Event handler for PebbleReadyEvent."""
+        self._common_exit_hook()
+
+    def _on_silence_exporter_pebble_ready(self, _):
+        """Event handler for the silence-exporter container's PebbleReadyEvent."""
         self._common_exit_hook()
 
     def _on_config_changed(self, _):

--- a/src/prometheus_alert_rules/silence_expiring_soon.rule
+++ b/src/prometheus_alert_rules/silence_expiring_soon.rule
@@ -1,0 +1,15 @@
+groups:
+- name: SilenceExpiringSoon
+  rules:
+  - alert: SilenceExpiringSoon
+    expr: |
+      (alertmanager_silence_endsat_timestamp_seconds - time()) > 0
+      and
+      (alertmanager_silence_endsat_timestamp_seconds - time()) < 259200
+    for: 0m
+    labels:
+      severity: warning
+    annotations:
+      summary: Alertmanager silence {{ $labels.id }} expires in < 72h (model {{ $labels.juju_model }})
+      description: |
+        Silence {{ $labels.id }} created by {{ $labels.created_by }} ends at {{ $value | humanizeTimestamp }}.

--- a/src/silence_exporter.py
+++ b/src/silence_exporter.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Silence-expiry exporter for Alertmanager.
+
+This script runs as a dedicated sidecar container in the Alertmanager pod. It polls the local
+Alertmanager API for silences and exposes, for every *active* silence, the epoch timestamp at
+which the silence ends. Prometheus can then alert when a silence is about to expire.
+
+Design constraints:
+- Standard library only. The sidecar image (a chiselled Python rock) has no pip and no extra
+  packages, so this module must not import anything outside the Python standard library.
+- The exporter shares the pod network namespace with the Alertmanager container, so it reaches
+  the API on localhost.
+
+Configuration is entirely via environment variables (set by the charm in the Pebble layer):
+- AM_URL:          Base URL of the Alertmanager API (default "http://localhost:9093").
+- EXPORTER_PORT:   Port to serve /metrics on (default 9095).
+- SCRAPE_INTERVAL: Seconds between polls of the Alertmanager API (default 30).
+- AM_CA_PATH:      Optional path to a CA cert used to validate the Alertmanager API when AM_URL
+                   is https.
+"""
+
+import json
+import logging
+import os
+import ssl
+import sys
+import threading
+import time
+import urllib.request
+from datetime import datetime, timezone
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import List, Optional
+
+logger = logging.getLogger("silence_exporter")
+
+# Metric names.
+_ENDSAT_METRIC = "alertmanager_silence_endsat_timestamp_seconds"
+_SCRAPE_ERROR_METRIC = "alertmanager_silence_exporter_scrape_error"
+
+
+def _parse_rfc3339(value: str) -> float:
+    """Parse an RFC3339 / ISO8601 timestamp into epoch seconds (UTC).
+
+    Alertmanager returns timestamps such as "2024-01-02T15:04:05.000Z" or with a numeric
+    offset like "2024-01-02T15:04:05+00:00".
+    """
+    # datetime.fromisoformat (3.11+) understands "Z", but the sidecar image may ship an older
+    # interpreter, so normalise the trailing "Z" to an explicit UTC offset first.
+    normalised = value.strip()
+    if normalised.endswith("Z"):
+        normalised = normalised[:-1] + "+00:00"
+    dt = datetime.fromisoformat(normalised)
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.timestamp()
+
+
+def _escape_label_value(value: str) -> str:
+    """Escape a label value per the Prometheus exposition format."""
+    return value.replace("\\", "\\\\").replace('"', '\\"').replace("\n", "\\n")
+
+
+def render_metrics(silences: List[dict], scrape_error: bool) -> str:
+    """Render the Prometheus exposition text for a list of silences.
+
+    Only silences whose ``status.state == "active"`` produce an endsAt series.
+
+    Cardinality guard: we deliberately expose only the ``id`` and ``created_by`` labels. The
+    free-text ``comment`` field is intentionally dropped because it is high-cardinality and
+    would bloat Prometheus' TSDB.
+    """
+    lines: List[str] = []
+
+    lines.append(f"# HELP {_ENDSAT_METRIC} Epoch timestamp at which an active silence ends.")
+    lines.append(f"# TYPE {_ENDSAT_METRIC} gauge")
+
+    for silence in silences:
+        state = (silence.get("status") or {}).get("state")
+        if state != "active":
+            continue
+
+        ends_at = silence.get("endsAt")
+        if not ends_at:
+            continue
+        try:
+            ends_at_epoch = _parse_rfc3339(ends_at)
+        except (ValueError, TypeError):
+            logger.warning("Skipping silence with unparsable endsAt: %r", ends_at)
+            continue
+
+        silence_id = _escape_label_value(str(silence.get("id", "")))
+        created_by = _escape_label_value(str(silence.get("createdBy", "")))
+        lines.append(
+            f'{_ENDSAT_METRIC}{{id="{silence_id}",created_by="{created_by}"}} {ends_at_epoch}'
+        )
+
+    lines.append(
+        f"# HELP {_SCRAPE_ERROR_METRIC} "
+        "1 if the last poll of the Alertmanager API failed, 0 otherwise."
+    )
+    lines.append(f"# TYPE {_SCRAPE_ERROR_METRIC} gauge")
+    lines.append(f"{_SCRAPE_ERROR_METRIC} {1 if scrape_error else 0}")
+
+    # Exposition format requires a trailing newline.
+    return "\n".join(lines) + "\n"
+
+
+class SilencePoller:
+    """Polls the Alertmanager silences API and holds the latest rendered exposition text."""
+
+    def __init__(self, am_url: str, ca_path: Optional[str], scrape_interval: float):
+        self._silences_url = am_url.rstrip("/") + "/api/v2/silences"
+        self._scrape_interval = scrape_interval
+        self._lock = threading.Lock()
+        # Start with an error state until the first successful scrape.
+        self._exposition = render_metrics([], scrape_error=True)
+
+        if self._silences_url.startswith("https"):
+            self._ssl_context: Optional[ssl.SSLContext] = ssl.create_default_context(
+                cafile=ca_path
+            )
+        else:
+            self._ssl_context = None
+
+    def _fetch_silences(self) -> List[dict]:
+        request = urllib.request.Request(self._silences_url, method="GET")
+        with urllib.request.urlopen(  # noqa: S310 (url scheme validated above)
+            request, timeout=10, context=self._ssl_context
+        ) as response:
+            return json.loads(response.read())
+
+    def poll_once(self) -> None:
+        """Poll the API once and refresh the cached exposition text."""
+        try:
+            silences = self._fetch_silences()
+            exposition = render_metrics(silences, scrape_error=False)
+        except Exception as e:  # noqa: BLE001 - self-health metric captures any failure
+            logger.warning("Failed to poll Alertmanager silences: %s", e)
+            exposition = render_metrics([], scrape_error=True)
+
+        with self._lock:
+            self._exposition = exposition
+
+    def run_forever(self) -> None:
+        """Poll in a loop, sleeping ``scrape_interval`` between polls."""
+        while True:
+            self.poll_once()
+            time.sleep(self._scrape_interval)
+
+    @property
+    def exposition(self) -> str:
+        """Return the latest rendered exposition text (thread-safe)."""
+        with self._lock:
+            return self._exposition
+
+
+def _make_handler(poller: SilencePoller):
+    class MetricsHandler(BaseHTTPRequestHandler):
+        def do_GET(self):  # noqa: N802 (http.server naming)
+            if self.path.rstrip("/") not in ("/metrics", ""):
+                self.send_error(404, "Not Found")
+                return
+            body = poller.exposition.encode("utf-8")
+            self.send_response(200)
+            self.send_header("Content-Type", "text/plain; version=0.0.4; charset=utf-8")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, format, *args):  # noqa: A002 - match base signature
+            # Silence the default stderr access log.
+            pass
+
+    return MetricsHandler
+
+
+def main() -> None:
+    """Entry point: start the poller thread and serve /metrics."""
+    logging.basicConfig(level=logging.INFO, stream=sys.stdout)
+
+    am_url = os.environ.get("AM_URL", "http://localhost:9093")
+    exporter_port = int(os.environ.get("EXPORTER_PORT", "9095"))
+    scrape_interval = float(os.environ.get("SCRAPE_INTERVAL", "30"))
+    ca_path = os.environ.get("AM_CA_PATH") or None
+
+    logger.info(
+        "Starting silence exporter: AM_URL=%s port=%s interval=%ss ca=%s",
+        am_url,
+        exporter_port,
+        scrape_interval,
+        ca_path,
+    )
+
+    poller = SilencePoller(am_url=am_url, ca_path=ca_path, scrape_interval=scrape_interval)
+
+    poller_thread = threading.Thread(target=poller.run_forever, daemon=True)
+    poller_thread.start()
+
+    server = ThreadingHTTPServer(("0.0.0.0", exporter_port), _make_handler(poller))
+    server.serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -21,6 +21,15 @@ logger = logging.getLogger(__name__)
 
 _METADATA = yaml.safe_load(Path("./charmcraft.yaml").read_text())
 ALERTMANAGER_IMAGE: str = _METADATA["resources"]["alertmanager-image"]["upstream-source"]
+SILENCE_EXPORTER_IMAGE: str = _METADATA["resources"]["silence-exporter-image"]["upstream-source"]
+
+# All OCI image resources required to deploy the charm from a local `.charm` file. Local charm
+# deploys don't consume `upstream-source` from charmcraft.yaml, so every resource must be passed
+# explicitly via `juju deploy/refresh --resource`.
+RESOURCES = {
+    "alertmanager-image": ALERTMANAGER_IMAGE,
+    "silence-exporter-image": SILENCE_EXPORTER_IMAGE,
+}
 
 AM_APP = "alertmanager"
 TEMPO_APP = "tempo"

--- a/tests/integration/test_grafana_source.py
+++ b/tests/integration/test_grafana_source.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 import jubilant
 import pytest
-from helpers import ALERTMANAGER_IMAGE, grafana_datasources
+from helpers import RESOURCES, grafana_datasources
 from tenacity import retry, stop_after_attempt, wait_fixed
 
 logger = logging.getLogger(__name__)
@@ -23,7 +23,7 @@ def test_deploy(juju, charm_path: Path):
     juju.deploy(
         str(charm_path),
         AM_APP,
-        resources={"alertmanager-image": ALERTMANAGER_IMAGE},
+        resources=RESOURCES,
         num_units=2,
         trust=True,
     )

--- a/tests/integration/test_kubectl_delete.py
+++ b/tests/integration/test_kubectl_delete.py
@@ -10,7 +10,7 @@ from pathlib import Path
 
 import jubilant
 import pytest
-from helpers import ALERTMANAGER_IMAGE, is_alertmanager_up
+from helpers import RESOURCES, is_alertmanager_up
 
 logger = logging.getLogger(__name__)
 
@@ -22,7 +22,7 @@ def test_deploy(juju, charm_path: Path):
     juju.deploy(
         str(charm_path),
         AM_APP,
-        resources={"alertmanager-image": ALERTMANAGER_IMAGE},
+        resources=RESOURCES,
         trust=True,
     )
     juju.wait(

--- a/tests/integration/test_logging.py
+++ b/tests/integration/test_logging.py
@@ -10,7 +10,7 @@ from pathlib import Path
 import jubilant
 import pytest
 import requests
-from helpers import ALERTMANAGER_IMAGE, get_unit_address
+from helpers import RESOURCES, get_unit_address
 from tenacity import retry, stop_after_attempt, wait_fixed
 
 logger = logging.getLogger(__name__)
@@ -24,7 +24,7 @@ def test_deploy(juju, charm_path: Path):
     juju.deploy(
         str(charm_path),
         APP_NAME,
-        resources={"alertmanager-image": ALERTMANAGER_IMAGE},
+        resources=RESOURCES,
         trust=True,
     )
     juju.deploy("loki-k8s", LOKI_APP, channel="dev/edge", trust=True)

--- a/tests/integration/test_remote_configuration.py
+++ b/tests/integration/test_remote_configuration.py
@@ -20,7 +20,7 @@ import jubilant
 import pytest
 import yaml
 from deepdiff import DeepDiff  # type: ignore[import]
-from helpers import ALERTMANAGER_IMAGE, get_alertmanager_config_from_file
+from helpers import RESOURCES, get_alertmanager_config_from_file
 
 TESTER_CHARM_PATH = "./tests/integration/remote_configuration_tester"
 TESTER_APP_METADATA = yaml.safe_load(
@@ -84,7 +84,7 @@ def test_deploy(juju, charm_path: Path, tester_charm_path: Path):
     juju.deploy(
         str(charm_path),
         APP_NAME,
-        resources={"alertmanager-image": ALERTMANAGER_IMAGE},
+        resources=RESOURCES,
         trust=True,
     )
     juju.deploy(

--- a/tests/integration/test_rescale_charm.py
+++ b/tests/integration/test_rescale_charm.py
@@ -16,7 +16,7 @@ from pathlib import Path
 
 import jubilant
 import pytest
-from helpers import ALERTMANAGER_IMAGE, get_leader_unit_num, is_alertmanager_up
+from helpers import RESOURCES, get_leader_unit_num, is_alertmanager_up
 
 logger = logging.getLogger(__name__)
 
@@ -29,7 +29,7 @@ def test_deploy(juju, charm_path: Path):
     juju.deploy(
         str(charm_path),
         AM_APP,
-        resources={"alertmanager-image": ALERTMANAGER_IMAGE},
+        resources=RESOURCES,
         num_units=10,
         trust=True,
     )

--- a/tests/integration/test_templates.py
+++ b/tests/integration/test_templates.py
@@ -12,7 +12,7 @@ from pathlib import Path
 import jubilant
 import pytest
 import yaml
-from helpers import ALERTMANAGER_IMAGE, is_alertmanager_up
+from helpers import RESOURCES, is_alertmanager_up
 from werkzeug.wrappers import Request, Response
 
 logger = logging.getLogger(__name__)
@@ -51,7 +51,7 @@ def test_deploy(juju, charm_path: Path, httpserver):
     juju.deploy(
         str(charm_path),
         AM_APP,
-        resources={"alertmanager-image": ALERTMANAGER_IMAGE},
+        resources=RESOURCES,
         config={"config_file": yaml.safe_dump(aconfig), "templates_file": TEMPLATE},
         trust=True,
     )

--- a/tests/integration/test_tls_web.py
+++ b/tests/integration/test_tls_web.py
@@ -10,7 +10,7 @@ from pathlib import Path
 
 import jubilant
 import pytest
-from helpers import ALERTMANAGER_IMAGE, curl, get_unit_address
+from helpers import RESOURCES, curl, get_unit_address
 
 logger = logging.getLogger(__name__)
 
@@ -23,7 +23,7 @@ def test_deploy(juju, charm_path: Path):
     juju.deploy(
         str(charm_path),
         AM_APP,
-        resources={"alertmanager-image": ALERTMANAGER_IMAGE},
+        resources=RESOURCES,
         trust=True,
     )
     juju.deploy("self-signed-certificates", CA_APP, channel="edge")

--- a/tests/integration/test_upgrade_charm.py
+++ b/tests/integration/test_upgrade_charm.py
@@ -16,7 +16,7 @@ from pathlib import Path
 
 import jubilant
 import pytest
-from helpers import ALERTMANAGER_IMAGE, is_alertmanager_up
+from helpers import RESOURCES, is_alertmanager_up
 
 # Cross-base upgrades (e.g. 24.04 -> 26.04) are not supported via juju refresh.
 # The charmhub charm is built for 24.04 (Python 3.12), while the local charm
@@ -43,7 +43,7 @@ def test_deploy(juju):
 
 
 def test_upgrade_in_isolation(juju, charm_path: Path):
-    juju.refresh(AM_APP, path=str(charm_path), resources={"alertmanager-image": ALERTMANAGER_IMAGE})
+    juju.refresh(AM_APP, path=str(charm_path), resources=RESOURCES)
     juju.wait(
         lambda s: jubilant.all_active(s, AM_APP) and jubilant.all_agents_idle(s, AM_APP),
         timeout=1000,
@@ -66,7 +66,7 @@ def test_upgrade_with_relations(juju, charm_path: Path):
         successes=3,
     )
 
-    juju.refresh(AM_APP, path=str(charm_path), resources={"alertmanager-image": ALERTMANAGER_IMAGE})
+    juju.refresh(AM_APP, path=str(charm_path), resources=RESOURCES)
     juju.wait(
         lambda s: jubilant.all_active(s, AM_APP, PROM_APP, KARMA_APP)
         and jubilant.all_agents_idle(s, AM_APP, PROM_APP, KARMA_APP),
@@ -88,7 +88,7 @@ def test_upgrade_with_multiple_units(juju, charm_path: Path):
         successes=3,
     )
 
-    juju.refresh(AM_APP, path=str(charm_path), resources={"alertmanager-image": ALERTMANAGER_IMAGE})
+    juju.refresh(AM_APP, path=str(charm_path), resources=RESOURCES)
     juju.wait(
         lambda s: jubilant.all_active(s, AM_APP, PROM_APP, KARMA_APP)
         and jubilant.all_agents_idle(s, AM_APP, PROM_APP, KARMA_APP),

--- a/tests/integration/test_workload_tracing_http.py
+++ b/tests/integration/test_workload_tracing_http.py
@@ -8,8 +8,8 @@ from pathlib import Path
 
 import jubilant
 from helpers import (
-    ALERTMANAGER_IMAGE,
     AM_APP,
+    RESOURCES,
     TEMPO_APP,
     assert_traces_in_tempo,
     deploy_tempo_stack,
@@ -29,7 +29,7 @@ def deploy_am_and_tempo(juju, charm_path: Path):
     juju.deploy(
         str(charm_path),
         AM_APP,
-        resources={"alertmanager-image": ALERTMANAGER_IMAGE},
+        resources=RESOURCES,
         trust=True,
     )
     tempo_apps = deploy_tempo_stack(juju)

--- a/tests/integration/test_workload_tracing_tls.py
+++ b/tests/integration/test_workload_tracing_tls.py
@@ -8,8 +8,8 @@ from pathlib import Path
 
 import jubilant
 from helpers import (
-    ALERTMANAGER_IMAGE,
     AM_APP,
+    RESOURCES,
     TEMPO_APP,
     assert_traces_in_tempo,
     deploy_tempo_stack,
@@ -34,7 +34,7 @@ def deploy_all(juju, charm_path: Path):
     juju.deploy(
         str(charm_path),
         AM_APP,
-        resources={"alertmanager-image": ALERTMANAGER_IMAGE},
+        resources=RESOURCES,
         trust=True,
     )
     tempo_apps = deploy_tempo_stack(juju)

--- a/tests/unit/helpers.py
+++ b/tests/unit/helpers.py
@@ -51,7 +51,8 @@ def begin_with_initial_hooks_isolated(context: Context, *, leader: bool = True) 
             Exec(["/usr/bin/amtool", "check-config", "/etc/alertmanager/alertmanager.yml"]),
         },
     )
-    state = State(config={"config_file": ""}, containers=[container])
+    exporter_container = Container("silence-exporter", can_connect=False)
+    state = State(config={"config_file": ""}, containers=[container, exporter_container])
     peer_rel = PeerRelation("replicas")
 
     state = context.run(context.on.install(), state)
@@ -69,7 +70,8 @@ def begin_with_initial_hooks_isolated(context: Context, *, leader: bool = True) 
 
     # state = state.with_can_connect("alertmanger")
     container = dataclasses.replace(container, can_connect=True)
-    state = dataclasses.replace(state, containers=[container])
+    exporter_container = dataclasses.replace(exporter_container, can_connect=True)
+    state = dataclasses.replace(state, containers=[container, exporter_container])
     state = context.run(context.on.pebble_ready(container), state)
 
     state = context.run(context.on.start(), state)

--- a/tests/unit/test_self_scrape_jobs.py
+++ b/tests/unit/test_self_scrape_jobs.py
@@ -35,14 +35,21 @@ class TestWithInitialHooks(unittest.TestCase):
     def test_self_scraping_job_with_no_peers(self, _mock_scheme, _mock_internal_url):
         scheme = "https"
         _mock_scheme.return_value = scheme
-        url_no_scheme = f"test-internal.url:{self.harness.charm._ports.api}"
-        _mock_internal_url.return_value = f"{scheme}://{url_no_scheme}"
+        host = "test-internal.url"
+        api_netloc = f"{host}:{self.harness.charm._ports.api}"
+        exporter_netloc = f"{host}:{self.harness.charm._ports.exporter}"
+        _mock_internal_url.return_value = f"{scheme}://{api_netloc}"
         jobs_expected = [
             {
                 "metrics_path": "/metrics",
                 "scheme": scheme,
-                "static_configs": [{"targets": [url_no_scheme]}],
-            }
+                "static_configs": [{"targets": [api_netloc]}],
+            },
+            {
+                "metrics_path": "/metrics",
+                "scheme": "http",
+                "static_configs": [{"targets": [exporter_netloc]}],
+            },
         ]
 
         jobs = self.harness.charm.self_scraping_job
@@ -57,25 +64,29 @@ class TestWithInitialHooks(unittest.TestCase):
         scheme = "https"
         _mock_scheme.return_value = scheme
 
-        targets = [
-            f"test-internal-0.url:{self.harness.charm._ports.api}",
-            f"test-internal-1.url:{self.harness.charm._ports.api}",
-            f"test-internal-2.url:{self.harness.charm._ports.api}",
-        ]
+        hosts = ["test-internal-0.url", "test-internal-1.url", "test-internal-2.url"]
+        api_targets = [f"{host}:{self.harness.charm._ports.api}" for host in hosts]
+        exporter_targets = [f"{host}:{self.harness.charm._ports.exporter}" for host in hosts]
         metrics_path = "/metrics"
-        _mock_internal_url.return_value = f"{scheme}://{targets[0]}"
+        _mock_internal_url.return_value = f"{scheme}://{api_targets[0]}"
 
         jobs_expected = [
             {
                 "metrics_path": metrics_path,
                 "scheme": scheme,
-                "static_configs": [{"targets": targets}],
-            }
+                "static_configs": [{"targets": api_targets}],
+            },
+            {
+                "metrics_path": metrics_path,
+                "scheme": "http",
+                "static_configs": [{"targets": exporter_targets}],
+            },
         ]
 
         # Add peers
-        for i, target in enumerate(targets[1:], 1):
+        for i, host in enumerate(hosts[1:], 1):
             unit_name = f"{self.app_name}/{i}"
+            target = f"{host}:{self.harness.charm._ports.api}"
             self.harness.add_relation_unit(self.peer_rel_id, unit_name)
             self.harness.update_relation_data(
                 self.peer_rel_id, unit_name, {"private_address": f"{scheme}://{target}"}

--- a/tests/unit/test_silence_exporter.py
+++ b/tests/unit/test_silence_exporter.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+"""Unit tests for the stdlib silence-expiry exporter render logic."""
+
+import unittest
+from datetime import datetime, timezone
+
+from silence_exporter import (
+    _ENDSAT_METRIC,
+    _SCRAPE_ERROR_METRIC,
+    _parse_rfc3339,
+    render_metrics,
+)
+
+
+def _metric_lines(exposition: str):
+    return [
+        line
+        for line in exposition.splitlines()
+        if line and not line.startswith("#")
+    ]
+
+
+class TestRenderMetrics(unittest.TestCase):
+    def test_active_silence_emits_endsat_series(self):
+        silences = [
+            {
+                "id": "abc-123",
+                "createdBy": "alice",
+                "comment": "some free text that must not leak into labels",
+                "endsAt": "2024-01-02T15:04:05Z",
+                "status": {"state": "active"},
+            }
+        ]
+        out = render_metrics(silences, scrape_error=False)
+
+        expected_epoch = datetime(
+            2024, 1, 2, 15, 4, 5, tzinfo=timezone.utc
+        ).timestamp()
+        self.assertIn(
+            f'{_ENDSAT_METRIC}{{id="abc-123",created_by="alice"}} {expected_epoch}',
+            out,
+        )
+        # Cardinality guard: comment must never appear.
+        self.assertNotIn("comment", out)
+        self.assertNotIn("free text", out)
+        # Self-health metric present and healthy.
+        self.assertIn(f"{_SCRAPE_ERROR_METRIC} 0", out)
+        # Exposition ends with a newline.
+        self.assertTrue(out.endswith("\n"))
+
+    def test_non_active_silences_are_skipped(self):
+        silences = [
+            {
+                "id": "expired-1",
+                "createdBy": "bob",
+                "endsAt": "2024-01-02T15:04:05Z",
+                "status": {"state": "expired"},
+            },
+            {
+                "id": "pending-1",
+                "createdBy": "bob",
+                "endsAt": "2024-01-02T15:04:05Z",
+                "status": {"state": "pending"},
+            },
+        ]
+        out = render_metrics(silences, scrape_error=False)
+        self.assertEqual(_metric_lines(out), [f"{_SCRAPE_ERROR_METRIC} 0"])
+
+    def test_scrape_error_sets_health_metric(self):
+        out = render_metrics([], scrape_error=True)
+        self.assertIn(f"{_SCRAPE_ERROR_METRIC} 1", out)
+
+    def test_label_values_are_escaped(self):
+        silences = [
+            {
+                "id": 'weird"id\\',
+                "createdBy": "line\nbreak",
+                "endsAt": "2024-01-02T15:04:05Z",
+                "status": {"state": "active"},
+            }
+        ]
+        out = render_metrics(silences, scrape_error=False)
+        self.assertIn(r'id="weird\"id\\"', out)
+        self.assertIn(r'created_by="line\nbreak"', out)
+
+    def test_unparsable_endsat_is_skipped(self):
+        silences = [
+            {
+                "id": "bad-ts",
+                "createdBy": "carol",
+                "endsAt": "not-a-timestamp",
+                "status": {"state": "active"},
+            }
+        ]
+        out = render_metrics(silences, scrape_error=False)
+        self.assertEqual(_metric_lines(out), [f"{_SCRAPE_ERROR_METRIC} 0"])
+
+
+class TestParseRfc3339(unittest.TestCase):
+    def test_zulu_suffix(self):
+        self.assertEqual(
+            _parse_rfc3339("2024-01-02T15:04:05Z"),
+            datetime(2024, 1, 2, 15, 4, 5, tzinfo=timezone.utc).timestamp(),
+        )
+
+    def test_explicit_offset(self):
+        self.assertEqual(
+            _parse_rfc3339("2024-01-02T15:04:05+00:00"),
+            datetime(2024, 1, 2, 15, 4, 5, tzinfo=timezone.utc).timestamp(),
+        )
+
+    def test_fractional_seconds(self):
+        # Should not raise.
+        self.assertIsInstance(_parse_rfc3339("2024-01-02T15:04:05.123Z"), float)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_silence_exporter_sidecar.py
+++ b/tests/unit/test_silence_exporter_sidecar.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+"""Unit tests for the silence-exporter sidecar wiring in the charm."""
+
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+import yaml
+from helpers import k8s_resource_multipatch
+from ops.testing import Harness
+
+from alertmanager import WorkloadManager
+from charm import AlertmanagerCharm
+
+RULES_DIR = Path(__file__).parent.parent.parent / "src" / "prometheus_alert_rules"
+
+
+class TestSilenceExporterSidecar(unittest.TestCase):
+    container_name = "silence-exporter"
+
+    @patch("lightkube.core.client.GenericSyncClient")
+    @patch.object(WorkloadManager, "check_config", lambda *a, **kw: ("ok", ""))
+    @k8s_resource_multipatch
+    @patch.object(WorkloadManager, "_alertmanager_version", property(lambda *_: "0.0.0"))
+    def setUp(self, *unused):
+        self.harness = Harness(AlertmanagerCharm)
+        self.addCleanup(self.harness.cleanup)
+        self.harness.set_leader(True)
+        self.harness.add_relation("replicas", "am")
+        self.harness.begin_with_initial_hooks()
+
+    def test_exporter_port_is_opened(self):
+        opened = {p.port for p in self.harness.charm.unit.opened_ports()}
+        self.assertIn(self.harness.charm._ports.exporter, opened)
+
+    def test_sidecar_layer_and_script_pushed(self):
+        self.harness.set_can_connect(self.container_name, True)
+        self.harness.container_pebble_ready(self.container_name)
+
+        container = self.harness.model.unit.get_container(self.container_name)
+
+        # The exporter script is pushed into the container.
+        pushed = container.pull(self.harness.charm._exporter_script_path).read()
+        expected = (
+            Path(__file__).parent.parent.parent / "src" / "silence_exporter.py"
+        ).read_text()
+        self.assertEqual(pushed, expected)
+
+        # The Pebble service is defined and runs the exporter.
+        service = container.get_plan().services[self.harness.charm._exporter_service_name]
+        self.assertEqual(service.command, "python3 /exporter.py")
+        self.assertEqual(service.startup, "enabled")
+        env = service.environment
+        self.assertEqual(env["EXPORTER_PORT"], "9095")
+        self.assertIn("AM_URL", env)
+        # No TLS configured -> no CA path in the env.
+        self.assertNotIn("AM_CA_PATH", env)
+
+
+class TestSilenceExpiringSoonRule(unittest.TestCase):
+    def test_rule_file_is_valid_yaml(self):
+        rule_path = RULES_DIR / "silence_expiring_soon.rule"
+        self.assertTrue(rule_path.exists())
+        parsed = yaml.safe_load(rule_path.read_text())
+        self.assertIn("groups", parsed)
+        group = parsed["groups"][0]
+        self.assertEqual(group["name"], "SilenceExpiringSoon")
+        self.assertEqual(group["rules"][0]["alert"], "SilenceExpiringSoon")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tox.ini
+++ b/tox.ini
@@ -53,7 +53,7 @@ description = Run unit tests
 setenv =
   {[testenv]setenv}
   JUJU_VERSION=3.0.3
-passenv = 
+passenv =
     PYTHONPATH
 allowlist_externals =
   {[testenv]allowlist_externals}


### PR DESCRIPTION
## Issue
#268 


## Solution
Add a sidecar container that polls the local Alertmanager API for active silences and exposes their expiry timestamps as Prometheus metrics on :9095, enabling alerting before a silence lapses.

- charm: add silence-exporter sidecar container, Pebble layer, script push, and TLS-aware CA handling; open port 9095 and add a second self-monitoring scrape job for the exporter (plain http, in-cluster)
- charmcraft.yaml: add silence-exporter container and silence-exporter-image resource (ubuntu/python rock)
- exporter: new stdlib-only src/silence_exporter.py rendering alertmanager_silence_endsat_timestamp_seconds (id, created_by labels only) plus a scrape-error self-health metric
- alerts: add SilenceExpiringSoon rule; fires when an active silence is due to expire within the next 72h
- tests: unit tests for exporter render logic and sidecar wiring; wire the new container into unit harness helpers; update self-scrape-job expectations for the second job; share deploy resources via a RESOURCES map across integration tests
- tox.ini: pass through session/dbus env vars for integration runs
- README: document the silence-expiry exporter and alert rule>


## Testing Instructions
- create an alert silence with less than 72 hours to expire
- check that the alert is generated

```
sudo k8s kubectl -n cos-lite exec -it alertmanager-0 -c alertmanager -- /bin/bash
root@alertmanager-0:/# amtool silence add alertname="DummySilenceTest" --duration=30m --comment="Testing" --alertmanager.url=https://alertmanager-0.alertmanager-endpoints.cos-lite.svc.cluster.local:9093
21cffeac-13f8-4824-ba73-8475de226bc1
root@alertmanager-0:/# amtool alert --alertmanager.url=https://alertmanager-0.alertmanager-endpoints.cos-lite.svc.cluster.local:9093
Alertname  Starts At                Summary                                                      State   
Watchdog   2026-07-20 14:34:01 UTC  Continuously firing alert to ensure Alertmanager is working  active  
root@alertmanager-0:/# amtool alert --alertmanager.url=https://alertmanager-0.alertmanager-endpoints.cos-lite.svc.cluster.local:9093
Alertname            Starts At                Summary                                                                                      State   
Watchdog             2026-07-20 14:34:01 UTC  Continuously firing alert to ensure Alertmanager is working                                  active  
SilenceExpiringSoon  2026-07-20 20:03:40 UTC  Alertmanager silence 21cffeac-13f8-4824-ba73-8475de226bc1 expires in < 72h (model cos-lite)  active
```
